### PR TITLE
Fix an unneeded overload in Report task

### DIFF
--- a/src/main/groovy/wooga/gradle/snyk/tasks/Report.groovy
+++ b/src/main/groovy/wooga/gradle/snyk/tasks/Report.groovy
@@ -1,14 +1,8 @@
 package wooga.gradle.snyk.tasks
 
 
-import wooga.gradle.snyk.cli.options.ProjectOption
-import wooga.gradle.snyk.cli.options.TestOption
-
-import javax.inject.Inject
-
 class Report extends Test {
 
-    @Inject
     Report() {
         reports.json.enabled = true
     }
@@ -16,12 +10,5 @@ class Report extends Test {
     @Override
     protected Boolean getIgnoreExitValue() {
         true
-    }
-
-    @Override
-    void addMainOptions(List<String> args) {
-        args.add("test")
-        args.addAll(getMappedOptions(this, TestOption))
-        args.addAll(getMappedOptions(this, ProjectOption))
     }
 }


### PR DESCRIPTION
## Description

I missed a meaning from a PR comment and merged without addressing the proper resolution. I cleaned up the `Report` class from otherwise unneeded overloads and imports.

## Changes

* ![FIX] unnneeded overload in `Report` task class

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"