### PR TITLE
Add project registration feature

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/snyk/SnykPluginPackeFileRegistrationIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/snyk/SnykPluginPackeFileRegistrationIntegrationSpec.groovy
@@ -1,0 +1,49 @@
+package wooga.gradle.snyk
+
+class SnykPluginPackeFileRegistrationIntegrationSpec extends SnykPluginRegistrationIntegrationSpec {
+
+    @Override
+    String getRegisterProjectInvocation(String projectId) {
+        "registerProject(file(${wrapValueBasedOnType(projectId, String)}))"
+    }
+
+    @Override
+    String getPackageId() {
+        "somePackage.json"
+    }
+
+    @Override
+    String getGeneratedTaskName(String baseTaskName) {
+        baseTaskName + "." + packageId
+    }
+
+    @Override
+    String getGeneratedExtensionName() {
+        extensionName + "." + packageId
+    }
+
+    @Override
+    File getRegisteredBuildFile() {
+        buildFile
+    }
+
+    @Override
+    void setupProject() {
+        createFile(packageId)
+    }
+
+    @Override
+    String getCustomPackageFileValue() {
+        "#projectDir#${File.separator}#packageName#"
+    }
+
+    @Override
+    String getCustomProjectNameValue() {
+        "#projectName#:#packageName#"
+    }
+
+    @Override
+    String getCustomSubProjectValue() {
+        null
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/snyk/SnykPluginRegistrationIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/snyk/SnykPluginRegistrationIntegrationSpec.groovy
@@ -1,0 +1,296 @@
+package wooga.gradle.snyk
+
+import com.wooga.gradle.test.ConventionSource
+import com.wooga.gradle.test.PropertyQueryTaskWriter
+import com.wooga.gradle.test.PropertyUtils
+import spock.lang.Unroll
+import wooga.gradle.snyk.cli.*
+
+abstract class SnykPluginRegistrationIntegrationSpec extends SnykIntegrationSpec {
+    def setup() {
+        buildFile << """
+        ${applyPlugin(SnykPlugin)}
+        """
+    }
+
+    abstract String getPackageId()
+
+    abstract String getRegisterProjectInvocation(String projectId)
+
+    abstract String getGeneratedExtensionName()
+
+    abstract String getGeneratedTaskName(String baseTaskName)
+
+    abstract File getRegisteredBuildFile()
+
+    abstract void setupProject()
+
+    abstract String getCustomPackageFileValue()
+
+    abstract String getCustomProjectNameValue()
+
+    abstract String getCustomSubProjectValue()
+
+    @Unroll
+    def "can configure property #property for registered project"() {
+        given: "a registered gradle sub project"
+        setupProject()
+        buildFile << """
+        ${extensionName} {
+            ${getRegisterProjectInvocation(packageId)} {
+                ${property} = ${value}
+            }
+        }
+        """.stripIndent()
+
+        when:
+        def query = new PropertyQueryTaskWriter("project.extensions.getByName('${generatedExtensionName}').${property}",
+                ".getOrNull()",
+                PropertyUtils.toCamelCase("query_${generatedExtensionName}.${property}")
+        )
+
+        query.write(registeredBuildFile)
+        def result = runTasksSuccessfully(query.taskName)
+
+        then:
+        query.matches(result, testValue)
+
+        where:
+        property                         | rawValue                             | type                              || expectedValue
+        "packageFile"                    | osPath("/some/package/file")         | "RegularFile"                     || _
+        "projectName"                    | "testProjectName"                    | "String"                          || _
+        "subProject"                     | "Sub1"                               | "String"                          || _
+        "allProjects"                    | true                                 | "Boolean"                         || _
+        "detectionDepth"                 | 22                                   | "Integer"                         || _
+        "exclude"                        | [osPath('/path/exclude1')]           | "List<File>"                      || _
+        "pruneRepeatedSubDependencies"   | true                                 | "Boolean"                         || _
+        "printDependencies"              | true                                 | "Boolean"                         || _
+        "remoteRepoUrl"                  | "http://remote/url1"                 | "String"                          || _
+        "includeDevelopmentDependencies" | true                                 | "Boolean"                         || _
+        "orgName"                        | "org1"                               | "String"                          || _
+        "ignorePolicy"                   | true                                 | "Boolean"                         || _
+        "showVulnerablePaths"            | VulnerablePathsOption.some           | "VulnerablePathsOption"           || _
+        "targetReference"                | "reference1"                         | "String"                          || _
+        "policyPath"                     | osPath("/path/to/policy1")           | "RegularFile"                     || _
+        "printJson"                      | true                                 | "Boolean"                         || _
+        "jsonOutputPath"                 | osPath("/path/to/json1")             | "RegularFile"                     || _
+        "printSarif"                     | true                                 | "Boolean"                         || _
+        "sarifOutputPath"                | osPath("/path/to/sarif1")            | "RegularFile"                     || _
+        "severityThreshold"              | SeverityThresholdOption.critical     | "SeverityThresholdOption"         || _
+        "failOn"                         | FailOnOption.all                     | "FailOnOption"                    || _
+        "compilerArguments"              | ['--flag1']                          | "List<String>"                    || _
+
+        "assetsProjectName"              | true                                 | "Boolean"                         || _
+        "packagesFolder"                 | osPath("/path/to/packages1")         | "Directory"                       || _
+        "projectNamePrefix"              | "prefix1"                            | "String"                          || _
+
+        "allSubProjects"                 | true                                 | "Boolean"                         || _
+        "configurationMatching"          | "config1"                            | "String"                          || _
+        "configurationAttributes"        | ['attribute1']                       | "List<String>"                    || _
+        "reachable"                      | true                                 | "Boolean"                         || _
+        "reachableTimeout"               | 22                                   | "Integer"                         || _
+        "initScript"                     | osPath("/path/to/initScript1")       | "RegularFile"                     || _
+
+        "scanAllUnmanaged"               | true                                 | "Boolean"                         || _
+
+        "strictOutOfSync"                | true                                 | "Boolean"                         || _
+
+        "command"                        | "command1"                           | "String"                          || _
+        "skipUnresolved"                 | true                                 | "Boolean"                         || _
+
+        "insecure"                       | true                                 | "Boolean"                         || _
+        "debug"                          | true                                 | "Boolean"                         || _
+
+        "token"                          | "test_token_1"                       | "String"                          || _
+
+        "executableName"                 | "snyk1"                              | "String"                          || _
+        "snykPath"                       | osPath("/path/to/snyk_home_1")       | "Directory"                       || _
+
+        "trustPolicies"                  | true                                 | "Boolean"                         || _
+        "projectLifecycle"               | [LifecycleOption.development]        | "List<LifecycleOption>"           || _
+        "projectBusinessCriticality"     | [BusinessCriticalityOption.critical] | "List<BusinessCriticalityOption>" || _
+        "projectTags"                    | ["foo": "bar"]                       | "Map<String, String>"             || _
+
+        value = (type != _) ? wrapValueBasedOnType(rawValue, type.toString(), wrapValueFallback) : rawValue
+        testValue = (expectedValue == _) ? rawValue : expectedValue
+    }
+
+    @Unroll
+    def "registered project extension sets custom value for property '#property'"() {
+        given: "a registered gradle sub project"
+        setupProject()
+        buildFile << """
+        ${extensionName} {
+            ${getRegisterProjectInvocation(packageId)}
+            ${property} = ${rootExtensionValue}
+        }
+        """.stripIndent()
+
+        when:
+        def query = new PropertyQueryTaskWriter("project.extensions.getByName('${generatedExtensionName}').${property}",
+                ".getOrNull()",
+                PropertyUtils.toCamelCase("query_${generatedExtensionName}.${property}")
+        )
+        query.write(registeredBuildFile)
+        def result = runTasksSuccessfully(query.taskName)
+
+        then:
+        def v = (testValue && String.isInstance(testValue)) ? testValue
+                .replaceAll("#projectName#", moduleName)
+                .replaceAll("#packageName#", packageId)
+                .replaceAll("#subProjectName#", packageId)
+                .replace("#projectDir#", projectDir.absolutePath) : testValue
+        query.matches(result, v)
+
+        when:
+        query = new PropertyQueryTaskWriter("${extensionName}.${property}")
+        query.write(buildFile)
+        result = runTasksSuccessfully(":${query.taskName}")
+
+        then:
+        def v2 = (testValue && String.isInstance(testValue)) ? testValue
+                .replaceAll("#projectName#", moduleName)
+                .replaceAll("#packageName#", packageId)
+                .replaceAll("#subProjectName#", packageId)
+                .replace("#projectDir#", projectDir.absolutePath) : testValue
+        !query.matches(result, v2)
+
+        where:
+        property      | rawValue               | type          | rawRootExtensionValue   || expectedValue
+        "packageFile" | customPackageFileValue | "RegularFile" | "/path/to/some/package" || _
+        "projectName" | customProjectNameValue | "String"      | "someName"              || _
+        "subProject"  | customSubProjectValue  | "String"      | "someSubProjectName"    || _
+
+        value = (type != _) ? wrapValueBasedOnType(rawValue, type.toString(), wrapValueFallback) : rawValue
+        rootExtensionValue = (type != _) ? wrapValueBasedOnType(rawRootExtensionValue, type.toString(), wrapValueFallback) : rawRootExtensionValue
+        testValue = (expectedValue == _) ? rawValue : expectedValue
+    }
+
+    @Unroll
+    def "registered project inherits conventions from root extension for property '#property'"() {
+        given: "a registered gradle sub project"
+        setupProject()
+        buildFile << """
+        ${extensionName} {
+            ${getRegisterProjectInvocation(packageId)}
+        }
+        """.stripIndent()
+
+        and: "a value set in the root extension"
+        conventionSource.write(buildFile, value.toString())
+
+        when:
+        def query = new PropertyQueryTaskWriter("project.extensions.getByName('${generatedExtensionName}').${property}",
+                ".getOrNull()",
+                PropertyUtils.toCamelCase("query_${generatedExtensionName}.${property}")
+        )
+        query.write(registeredBuildFile)
+        def result = runTasksSuccessfully(query.taskName)
+
+        then:
+        query.matches(result, testValue)
+
+        where:
+        property                         | rawValue                             | type                              | conventionSource                                    | invocation || expectedValue
+        "allProjects"                    | true                                 | "Boolean"                         | ConventionSource.extension(extensionName, property) | _          || _
+        "detectionDepth"                 | 22                                   | "Integer"                         | ConventionSource.extension(extensionName, property) | _          || _
+        "exclude"                        | [osPath('/path/exclude1')]           | "List<File>"                      | ConventionSource.extension(extensionName, property) | _          || _
+        "pruneRepeatedSubDependencies"   | true                                 | "Boolean"                         | ConventionSource.extension(extensionName, property) | _          || _
+        "printDependencies"              | true                                 | "Boolean"                         | ConventionSource.extension(extensionName, property) | _          || _
+        "remoteRepoUrl"                  | "http://remote/url1"                 | "String"                          | ConventionSource.extension(extensionName, property) | _          || _
+        "includeDevelopmentDependencies" | true                                 | "Boolean"                         | ConventionSource.extension(extensionName, property) | _          || _
+        "orgName"                        | "org1"                               | "String"                          | ConventionSource.extension(extensionName, property) | _          || _
+        "ignorePolicy"                   | true                                 | "Boolean"                         | ConventionSource.extension(extensionName, property) | _          || _
+        "showVulnerablePaths"            | VulnerablePathsOption.some           | "VulnerablePathsOption"           | ConventionSource.extension(extensionName, property) | _          || _
+        "targetReference"                | "reference1"                         | "String"                          | ConventionSource.extension(extensionName, property) | _          || _
+        "policyPath"                     | osPath("/path/to/policy1")           | "RegularFile"                     | ConventionSource.extension(extensionName, property) | _          || _
+        "printJson"                      | true                                 | "Boolean"                         | ConventionSource.extension(extensionName, property) | _          || _
+        "jsonOutputPath"                 | osPath("/path/to/json1")             | "RegularFile"                     | ConventionSource.extension(extensionName, property) | _          || _
+        "printSarif"                     | true                                 | "Boolean"                         | ConventionSource.extension(extensionName, property) | _          || _
+        "sarifOutputPath"                | osPath("/path/to/sarif1")            | "RegularFile"                     | ConventionSource.extension(extensionName, property) | _          || _
+        "severityThreshold"              | SeverityThresholdOption.critical     | "SeverityThresholdOption"         | ConventionSource.extension(extensionName, property) | _          || _
+        "failOn"                         | FailOnOption.all                     | "FailOnOption"                    | ConventionSource.extension(extensionName, property) | _          || _
+        "compilerArguments"              | ['--flag1']                          | "List<String>"                    | ConventionSource.extension(extensionName, property) | _          || _
+
+        "assetsProjectName"              | true                                 | "Boolean"                         | ConventionSource.extension(extensionName, property) | _          || _
+        "packagesFolder"                 | osPath("/path/to/packages1")         | "Directory"                       | ConventionSource.extension(extensionName, property) | _          || _
+        "projectNamePrefix"              | "prefix1"                            | "String"                          | ConventionSource.extension(extensionName, property) | _          || _
+
+        "allSubProjects"                 | true                                 | "Boolean"                         | ConventionSource.extension(extensionName, property) | _          || _
+        "configurationMatching"          | "config1"                            | "String"                          | ConventionSource.extension(extensionName, property) | _          || _
+        "configurationAttributes"        | ['attribute1']                       | "List<String>"                    | ConventionSource.extension(extensionName, property) | _          || _
+        "reachable"                      | true                                 | "Boolean"                         | ConventionSource.extension(extensionName, property) | _          || _
+        "reachableTimeout"               | 22                                   | "Integer"                         | ConventionSource.extension(extensionName, property) | _          || _
+        "initScript"                     | osPath("/path/to/initScript1")       | "RegularFile"                     | ConventionSource.extension(extensionName, property) | _          || _
+
+        "scanAllUnmanaged"               | true                                 | "Boolean"                         | ConventionSource.extension(extensionName, property) | _          || _
+
+        "strictOutOfSync"                | true                                 | "Boolean"                         | ConventionSource.extension(extensionName, property) | _          || _
+
+        "command"                        | "command1"                           | "String"                          | ConventionSource.extension(extensionName, property) | _          || _
+        "skipUnresolved"                 | true                                 | "Boolean"                         | ConventionSource.extension(extensionName, property) | _          || _
+
+        "insecure"                       | true                                 | "Boolean"                         | ConventionSource.extension(extensionName, property) | _          || _
+        "debug"                          | true                                 | "Boolean"                         | ConventionSource.extension(extensionName, property) | _          || _
+
+        "token"                          | "test_token_1"                       | "String"                          | ConventionSource.extension(extensionName, property) | _          || _
+
+        "executableName"                 | "snyk1"                              | "String"                          | ConventionSource.extension(extensionName, property) | _          || _
+        "snykPath"                       | osPath("/path/to/snyk_home_1")       | "Directory"                       | ConventionSource.extension(extensionName, property) | _          || _
+
+        "trustPolicies"                  | true                                 | "Boolean"                         | ConventionSource.extension(extensionName, property) | _          || _
+        "projectLifecycle"               | [LifecycleOption.development]        | "List<LifecycleOption>"           | ConventionSource.extension(extensionName, property) | _          || _
+        "projectBusinessCriticality"     | [BusinessCriticalityOption.critical] | "List<BusinessCriticalityOption>" | ConventionSource.extension(extensionName, property) | _          || _
+        "projectTags"                    | ["foo": "bar"]                       | "Map<String, String>"             | ConventionSource.extension(extensionName, property) | _          || _
+
+        value = (type != _) ? wrapValueBasedOnType(rawValue, type.toString(), wrapValueFallback) : rawValue
+        testValue = (expectedValue == _) ? rawValue : expectedValue
+    }
+
+    @Unroll
+    def "can access task #taskName from generated project extension"() {
+        setupProject()
+        buildFile << """
+        ${extensionName} {
+            ${getRegisterProjectInvocation(packageId)} {
+                ${taskName} {
+                    ${property} = ${value}
+                }
+            }
+        }
+        """.stripIndent()
+
+        when:
+        def query = new PropertyQueryTaskWriter("project.extensions.getByName('${generatedExtensionName}').${taskName}.flatMap{it.${property}}",
+                ".getOrNull()",
+                PropertyUtils.toCamelCase("query_${generatedExtensionName}.${taskName}.${property}")
+        )
+
+        query.write(registeredBuildFile)
+        def result = runTasksSuccessfully(query.taskName)
+
+        then:
+        query.matches(result, testValue)
+
+        when: "when checking the value at the generated task directly"
+        query = new PropertyQueryTaskWriter("project.tasks.getByName('${getGeneratedTaskName(taskName)}').${property}",
+                ".getOrNull()",
+                PropertyUtils.toCamelCase("query_${getGeneratedTaskName(taskName)}.${property}")
+        )
+
+        query.write(registeredBuildFile)
+        result = runTasksSuccessfully(query.taskName)
+
+        then:
+        query.matches(result, testValue)
+
+        where:
+        taskName      | property | rawValue | type     || expectedValue
+        "snykTest"    | "token"  | "123456" | "String" || _
+        "snykMonitor" | "token"  | "123456" | "String" || _
+        "snykReport"  | "token"  | "123456" | "String" || _
+
+        value = (type != _) ? wrapValueBasedOnType(rawValue, type.toString(), wrapValueFallback) : rawValue
+        testValue = (expectedValue == _) ? rawValue : expectedValue
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/snyk/SnykPluginSubProjectRegistrationIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/snyk/SnykPluginSubProjectRegistrationIntegrationSpec.groovy
@@ -1,0 +1,93 @@
+package wooga.gradle.snyk
+
+import com.wooga.gradle.test.PropertyQueryTaskWriter
+import spock.lang.Unroll
+
+class SnykPluginSubProjectRegistrationIntegrationSpec extends SnykPluginRegistrationIntegrationSpec {
+
+    @Override
+    String getPackageId() {
+        "sub1"
+    }
+
+    @Override
+    String getRegisterProjectInvocation(String projectId) {
+        "registerProject(findProject(${wrapValueBasedOnType(projectId, String)}))"
+    }
+
+    @Override
+    String getGeneratedExtensionName() {
+        extensionName
+    }
+
+    @Override
+    File getRegisteredBuildFile() {
+        new File(projectDir, "${packageId}/build.gradle")
+    }
+
+    @Override
+    void setupProject() {
+        addSubproject(packageId, "")
+    }
+
+    @Override
+    String getCustomPackageFileValue() {
+        null
+    }
+
+    @Override
+    String getCustomProjectNameValue() {
+        "#projectName#:#subProjectName#"
+    }
+
+    @Override
+    String getCustomSubProjectValue() {
+        "#subProjectName#"
+    }
+
+    @Override
+    String getGeneratedTaskName(String baseTaskName) {
+        baseTaskName
+    }
+
+    @Unroll
+    def "can register and configure multiple sub projects with #method"() {
+        given: "multiple sub projects"
+        def sub1Dir = addSubproject("sub1", "")
+        def sub1BuildFile = new File(sub1Dir, "build.gradle")
+        def sub2Dir = addSubproject("sub2", "")
+        def sub2BuildFile = new File(sub2Dir, "build.gradle")
+
+        buildFile << """
+        ${extensionName} {
+            ${method} {
+                ${property} = ${value}
+            }
+        }
+        """.stripIndent()
+
+        when:
+        def query1 = new PropertyQueryTaskWriter("${extensionName}.${property}")
+        query1.write(sub1BuildFile)
+        def result = runTasksSuccessfully(query1.taskName)
+
+        then:
+        query1.matches(result, testValue)
+
+        when:
+        def query2 = new PropertyQueryTaskWriter("${extensionName}.${property}")
+        query2.write(sub2BuildFile)
+        result = runTasksSuccessfully(query2.taskName)
+
+        then:
+        query2.matches(result, testValue)
+
+        where:
+        method                                                                        | property | rawValue | type     || expectedValue
+        "registerProject([project.findProject('sub1'), project.findProject('sub2')])" | "token"  | "123456" | "String" || _
+        "registerAllSubProjects()"                                                    | "token"  | "123456" | "String" || _
+
+        value = (type != _) ? wrapValueBasedOnType(rawValue, type.toString(), wrapValueFallback) : rawValue
+        testValue = (expectedValue == _) ? rawValue : expectedValue
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/snyk/tasks/SnykInstallIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/snyk/tasks/SnykInstallIntegrationSpec.groovy
@@ -150,6 +150,13 @@ class SnykInstallIntegrationSpec extends SnykIntegrationSpec {
         def query = new PropertyQueryTaskWriter("${subjectUnderTestName}.${property}")
         query.write(buildFile)
 
+        and: "set minimal needed properties"
+        appendToSubjectTask("""
+        installationDir = file('build/installs')
+        executableName = 'snyk'
+        version = '1.0.0'
+        """.stripIndent())
+
         and: "tasks to execute"
         def tasks = [subjectUnderTestName, cliOption]
         if (rawValue != _) {
@@ -160,6 +167,7 @@ class SnykInstallIntegrationSpec extends SnykIntegrationSpec {
         and: "disable subject under test to no fail"
         appendToSubjectTask("enabled=false")
 
+
         when:
         def result = runTasksSuccessfully(*tasks)
 
@@ -167,10 +175,10 @@ class SnykInstallIntegrationSpec extends SnykIntegrationSpec {
         query.matches(result, expectedValue)
 
         where:
-        property          | cliOption            | rawValue                        | returnValue | type
-        "installationDir" | "--installation-dir" | osPath("/path/to/output.sarif") | _           | "CLIString"
-        "executableName"  | "--executable-name"  | "my-custom-snyk"                | _           | "CLIString"
-        "version"         | "--version"          | "22.11.33"                      | _           | "CLIString"
+        property          | cliOption            | rawValue                      | returnValue | type
+        "installationDir" | "--installation-dir" | osPath("/path/to/installDir") | _           | "CLIString"
+        "executableName"  | "--executable-name"  | "my-custom-snyk"              | _           | "CLIString"
+        "version"         | "--version"          | "22.11.33"                    | _           | "CLIString"
 
         value = wrapValueBasedOnType(rawValue, type, wrapValueFallback)
         expectedValue = returnValue == _ ? rawValue : returnValue

--- a/src/main/groovy/wooga/gradle/snyk/ProjectRegistrationHandler.groovy
+++ b/src/main/groovy/wooga/gradle/snyk/ProjectRegistrationHandler.groovy
@@ -1,0 +1,9 @@
+package wooga.gradle.snyk
+
+import org.gradle.api.Project
+
+interface ProjectRegistrationHandler {
+    SnykPluginExtension registerProject(File projectFile, SnykRootPluginExtension parentExtension)
+
+    SnykPluginExtension registerProject(Project project, SnykRootPluginExtension parentExtension)
+}

--- a/src/main/groovy/wooga/gradle/snyk/SnykInstallSpec.groovy
+++ b/src/main/groovy/wooga/gradle/snyk/SnykInstallSpec.groovy
@@ -40,7 +40,6 @@ trait SnykInstallSpec extends BaseSpec {
         installationDir.set(new File(value))
     }
 
-
     private final Property<String> executableName = objects.property(String)
 
     @Internal

--- a/src/main/groovy/wooga/gradle/snyk/SnykPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/snyk/SnykPluginExtension.groovy
@@ -1,68 +1,54 @@
-/*
- * Copyright 2022 Wooga GmbH
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package wooga.gradle.snyk
 
+import org.gradle.api.Action
+import org.gradle.api.Project
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Internal
-import wooga.gradle.snyk.cli.CommonArgumentSpec
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.util.ConfigureUtil
 import wooga.gradle.snyk.cli.SnykTaskSpec
 import wooga.gradle.snyk.cli.commands.MonitorProjectCommandSpec
+import wooga.gradle.snyk.tasks.Monitor
+import wooga.gradle.snyk.tasks.Report
+import wooga.gradle.snyk.tasks.Test
 
 trait SnykPluginExtension implements
         MonitorProjectCommandSpec,
-        SnykTaskSpec,
-        CommonArgumentSpec,
-        SnykInstallSpec,
-        SnykStrategySpec {
-    private final Property<Boolean> autoDownload = objects.property(Boolean)
+        SnykTaskSpec {
 
-    /**
-     * @return Whether to auto download the snyk executable if not found
-     */
-    Property<Boolean> getAutoDownload() {
-        autoDownload
+    abstract TaskProvider<Test> getSnykTest()
+
+    abstract TaskProvider<Monitor> getSnykMonitor()
+
+    abstract TaskProvider<Report> getSnykReport()
+
+    abstract Project getProject()
+
+    void snykTest(Action<Test> action) {
+        snykTest.configure(action)
     }
 
-    void setAutoDownload(Provider<Boolean> value) {
-        autoDownload.set(value)
+    void snykTest(Closure configure) {
+        snykTest.configure(ConfigureUtil.configureUsing(configure))
     }
 
-    void setAutoDownload(Boolean value) {
-        autoDownload.set(value)
+    void snykMonitor(Action<Monitor> action) {
+        snykMonitor.configure(action)
     }
 
-    private final Property<Boolean> autoUpdate = objects.property(Boolean)
-
-    /**
-     * @return Whether to auto update the snyk executable if present
-     */
-    Property<Boolean> getAutoUpdate() {
-        autoUpdate
+    void snykMonitor(Closure configure) {
+        snykMonitor.configure(ConfigureUtil.configureUsing(configure))
     }
 
-    void setAutoUpdate(Provider<Boolean> value) {
-        autoUpdate.set(value)
+    void snykReport(Action<Report> action) {
+        snykReport.configure(action)
     }
 
-    void setAutoUpdate(Boolean value) {
-        autoUpdate.set(value)
+    void snykReport(Closure configure) {
+        snykReport.configure(ConfigureUtil.configureUsing(configure))
     }
 
     private final Property<Boolean> jsonReportsEnabled = objects.property(Boolean)

--- a/src/main/groovy/wooga/gradle/snyk/SnykRootPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/snyk/SnykRootPluginExtension.groovy
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2022 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.snyk
+
+import org.gradle.api.Action
+import org.gradle.api.Project
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.util.ConfigureUtil
+
+trait SnykRootPluginExtension implements SnykPluginExtension, SnykInstallSpec, SnykStrategySpec {
+    private final Property<Boolean> autoDownload = objects.property(Boolean)
+
+    /**
+     * @return Whether to auto download the snyk executable if not found
+     */
+    Property<Boolean> getAutoDownload() {
+        autoDownload
+    }
+
+    void setAutoDownload(Provider<Boolean> value) {
+        autoDownload.set(value)
+    }
+
+    void setAutoDownload(Boolean value) {
+        autoDownload.set(value)
+    }
+
+    private final Property<Boolean> autoUpdate = objects.property(Boolean)
+
+    /**
+     * @return Whether to auto update the snyk executable if present
+     */
+    Property<Boolean> getAutoUpdate() {
+        autoUpdate
+    }
+
+    void setAutoUpdate(Provider<Boolean> value) {
+        autoUpdate.set(value)
+    }
+
+    void setAutoUpdate(Boolean value) {
+        autoUpdate.set(value)
+    }
+
+    abstract ProjectRegistrationHandler getRegisterProjectHandler()
+
+    /**
+     * Registers a new snyk project for a given File. The file can either point
+     * to a directory or a file which should be understood by the snyk cli.
+     *
+     * @param project a file to register as a snyk project
+     * @return a {@link SnykPluginExtension} object
+     */
+    SnykPluginExtension registerProject(File project) {
+        registerProjectHandler.registerProject(project, this)
+    }
+
+    /**
+     * Registers a new snyk project for a given File. The file can either point
+     * to a directory or a file which should be understood by the snyk cli.
+     *
+     * @param project a file to register as a snyk project
+     * @param action a configuration action which gets with the newly added [snyk] extension.
+     * @return a {@link SnykPluginExtension} object
+     */
+    SnykPluginExtension registerProject(File project, Action<SnykPluginExtension> action) {
+        def extension = registerProject(project)
+        action.execute(extension)
+        extension
+    }
+
+    /**
+     * Registers a new snyk project for a given File. The file can either point
+     * to a directory or a file which should be understood by the snyk cli.
+     *
+     * @param project a file to register as a snyk project
+     * @param action a configuration closure which gets with the newly added [snyk] extension.
+     * @return a {@link SnykPluginExtension} object
+     */
+    SnykPluginExtension registerProject(File project, Closure configure) {
+        registerProject(project, ConfigureUtil.configureUsing(configure))
+    }
+
+    /**
+     * Registers a single gradle sub project as a snyk project.
+     * Each registered project will be configured with a custom snyk extension
+     * and snyk tasks (snykTest, snykMonitor, snykReport)
+     *
+     * @param subProject the project to register
+     * @return a {@link SnykPluginExtension} object
+     */
+    SnykPluginExtension registerProject(Project subProject) {
+        registerProjectHandler.registerProject(subProject, this)
+    }
+
+    /**
+     * Registers a single gradle sub project as a snyk project.
+     * Each registered project will be configured with a custom snyk extension
+     * and snyk tasks (snykTest, snykMonitor, snykReport)
+     *
+     * @param subProject the project to register
+     * @param action a configuration action which gets with the newly added [snyk] extension on the subproject
+     * @return a {@link SnykPluginExtension} object
+     */
+    SnykPluginExtension registerProject(Project subProject, Action<SnykPluginExtension> action) {
+        def extension = registerProject(subProject)
+        action.execute(extension)
+        extension
+    }
+
+    /**
+     * Registers a single gradle sub project as a snyk project.
+     * Each registered project will be configured with a custom snyk extension
+     * and snyk tasks (snykTest, snykMonitor, snykReport)
+     *
+     * @param subProject the project to register
+     * @param configure configuration closure which gets with the newly added [snyk] extension on the subproject
+     * @return a {@link SnykPluginExtension} object
+     */
+    SnykPluginExtension registerProject(Project subProject, Closure configure) {
+        registerProject(subProject, ConfigureUtil.configureUsing(configure))
+    }
+
+    /**
+     * Registers multiple subprojects provided as a {@code Iteratble<Project>}.
+     * The method loops over the provided projects and calls {@link #registerProject}
+     * @param subProjects the projects to register
+     */
+    void registerProject(Iterable<Project> subProjects) {
+        subProjects.each { registerProject(it) }
+    }
+
+    /**
+     * Registers multiple subprojects provided as a {@code Iteratble<Project>}.
+     * The method loops over the provided projects and calls {@link #registerProject}
+     *
+     * @param subProjects the projects to register
+     * @param configure a configuration action which gets called for each provided subproject
+     */
+    void registerProject(Iterable<Project> subProjects, Action<SnykPluginExtension> action) {
+        subProjects.each {
+            registerProject(it, action)
+        }
+    }
+
+    /**
+     * Registers multiple subprojects provided as a {@code Iteratble<Project>}.
+     * The method loops over the provided projects and calls {@link #registerProject}
+     *
+     * @param subProjects the projects to register
+     * @param configure a configuration closure which gets called for each provided subproject
+     */
+    void registerProject(Iterable<Project> subProjects, Closure configure) {
+        subProjects.each {
+            registerProject(it, configure)
+        }
+    }
+
+    /**
+     * Registers all gradle sub projects as snyk projects.
+     * The method loops over all gradle sub projects and calls
+     * {@link registerProject}
+     *
+     * @see SnykRootPluginExtension.#registerProject
+     */
+    void registerAllSubProjects() {
+        project.subprojects { Project it ->
+            registerProject(it)
+        }
+    }
+
+    /**
+     * Registers all gradle sub projects as snyk projects.
+     * The method loops over all gradle sub projects and calls
+     * {@code registerProject} with the given {@code Action} object.
+     *
+     * @param action a configuration action which gets called for each subproject
+     *
+     * @see SnykRootPluginExtension.#registerProject
+     */
+    void registerAllSubProjects(Action<SnykPluginExtension> action) {
+        project.subprojects { Project it ->
+            registerProject(it, action)
+        }
+    }
+
+    /**
+     * Registers all gradle sub projects as snyk projects.
+     * The method loops over all gradle sub projects and calls
+     * {@code registerProject} with the given {@code Closure} object.
+     *
+     * @param configure a configuration closure which gets called for each subproject
+     *
+     * @see SnykRootPluginExtension.#registerProject
+     */
+    void registerAllSubProjects(Closure configure) {
+        /* Why not calling `registerAllSubProjects(ConfigureUtil.configureUsing(configure))`?
+           This would put the scope of the closure into the wrong extension. We either let
+           the actual working implementation of `registerProject(Project, Closure)` convert it,
+           or we would need to adjust the closure delegate manually somewhere in our code.
+           I think it is cleaner to have some reduntant code over the alternatives.
+        */
+        project.subprojects { Project it ->
+            registerProject(it, configure)
+        }
+    }
+
+    @Override
+    Property<String> getExecutableName() {
+        return SnykInstallSpec.super.getExecutableName()
+    }
+
+    @Override
+    void setExecutableName(Provider<String> value) {
+        SnykInstallSpec.super.setExecutableName(value)
+    }
+
+    @Override
+    void setExecutableName(String value) {
+        SnykInstallSpec.super.setExecutableName(value)
+    }
+}

--- a/src/main/groovy/wooga/gradle/snyk/internal/DefaultSnykRootPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/snyk/internal/DefaultSnykRootPluginExtension.groovy
@@ -18,21 +18,25 @@ package wooga.gradle.snyk.internal
 
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskProvider
-import wooga.gradle.snyk.SnykPluginExtension
+import wooga.gradle.snyk.ProjectRegistrationHandler
+import wooga.gradle.snyk.SnykRootPluginExtension
 import wooga.gradle.snyk.tasks.Monitor
 import wooga.gradle.snyk.tasks.Report
 import wooga.gradle.snyk.tasks.Test
 
-class DefaultSnykPluginExtension implements SnykPluginExtension {
+class DefaultSnykRootPluginExtension implements SnykRootPluginExtension {
+
     final TaskProvider<Test> snykTest
     final TaskProvider<Monitor> snykMonitor
     final TaskProvider<Report> snykReport
+    final ProjectRegistrationHandler registerProjectHandler
     final Project project
 
-    DefaultSnykPluginExtension(Project project, TaskProvider<Test> snykTest, TaskProvider<Monitor> snykMonitor, TaskProvider<Report> snykReport) {
+    DefaultSnykRootPluginExtension(Project project, TaskProvider<Test> snykTest, TaskProvider<Monitor> snykMonitor, TaskProvider<Report> snykReport, ProjectRegistrationHandler registerProjectHandler) {
         this.project = project
         this.snykTest = snykTest
         this.snykMonitor = snykMonitor
         this.snykReport = snykReport
+        this.registerProjectHandler = registerProjectHandler
     }
 }

--- a/src/main/groovy/wooga/gradle/snyk/tasks/SnykInstall.groovy
+++ b/src/main/groovy/wooga/gradle/snyk/tasks/SnykInstall.groovy
@@ -5,6 +5,7 @@ import groovy.json.JsonSlurper
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import wooga.gradle.snyk.SnykInstallSpec
 import wooga.gradle.snyk.tasks.internal.CachedGroliphantDownloader
@@ -15,7 +16,9 @@ class SnykInstall extends DefaultTask implements SnykInstallSpec {
 
     private static final String SNYK_RELEASE_JSON_URL = "https://static.snyk.io/cli/%s/release.json"
 
-    private final Provider<RegularFile> snykExecutable
+    @OutputFile
+    final Provider<RegularFile> snykExecutable
+
     private final Provider<Map<String, SnykDownloadAsset>> snykReleasesProvider
 
     SnykInstall() {

--- a/src/test/groovy/wooga/gradle/snyk/SnykPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/snyk/SnykPluginSpec.groovy
@@ -19,6 +19,7 @@ package wooga.gradle.snyk
 import nebula.test.ProjectSpec
 import spock.lang.Unroll
 import wooga.gradle.snyk.tasks.Monitor
+import wooga.gradle.snyk.tasks.Report
 import wooga.gradle.snyk.tasks.SnykInstall
 import wooga.gradle.snyk.tasks.Test
 
@@ -43,12 +44,12 @@ class SnykPluginSpec extends ProjectSpec {
         taskName      | taskType
         "snykTest"    | Test
         "snykMonitor" | Monitor
+        "snykReport"  | Report
         "snykInstall" | SnykInstall
     }
 
-
     @Unroll
-    def 'Creates the [#extensionName] extension with type #extensionType'() {
+    def "Creates the '#extensionName' extension with type #extensionType"() {
         given:
         assert !project.plugins.hasPlugin(PLUGIN_NAME)
         assert !project.extensions.findByName(extensionName)
@@ -62,6 +63,200 @@ class SnykPluginSpec extends ProjectSpec {
 
         where:
         extensionName | extensionType
-        'snyk'        | SnykPluginExtension
+        'snyk'        | SnykRootPluginExtension
+    }
+
+    @Unroll
+    def "Creates the '#extensionName' extension with type #extensionType on registered subproject"() {
+        given: "a project with snyk plugin added"
+        project.plugins.apply(PLUGIN_NAME)
+
+        and: "a sub project"
+        def subProject = addSubproject("sub1")
+
+        and: "task does not yet exist"
+        assert !subProject.extensions.findByName(extensionName)
+
+        and:
+        SnykRootPluginExtension rootExtension = project.extensions.findByName(extensionName) as SnykRootPluginExtension
+
+        when:
+        rootExtension.registerProject(subProject)
+
+        then:
+        def extension = subProject.extensions.findByName(extensionName)
+        extensionType.isInstance extension
+        !notOfType.isInstance(extension)
+
+        where:
+        extensionName | extensionType       | notOfType
+        'snyk'        | SnykPluginExtension | SnykRootPluginExtension
+    }
+
+    @Unroll
+    def "Creates task #taskName on registered subproject"() {
+        given: "a project with snyk plugin added"
+        project.plugins.apply(PLUGIN_NAME)
+
+        and: "a sub project"
+        def subProject = addSubproject("sub1")
+
+        and: "task does not yet exist"
+        assert !subProject.tasks.findByName(taskName)
+
+        and:
+        SnykRootPluginExtension extension = project.extensions.findByName("snyk") as SnykRootPluginExtension
+
+        when:
+        extension.registerProject(subProject)
+
+        then:
+        subProject.extensions.findByName("snyk")
+        def task = project.tasks.findByName(taskName)
+        taskType.isInstance(task)
+
+        where:
+        taskName      | taskType
+        "snykTest"    | Test
+        "snykMonitor" | Monitor
+        "snykReport"  | Report
+    }
+
+    @Unroll
+    def "Registers multiple subprojects with #registerType"() {
+        given: "a project with snyk plugin added"
+        project.plugins.apply(PLUGIN_NAME)
+
+        and: "multiple sub projects"
+        def subProject1 = addSubproject("sub1")
+        def subProject2 = addSubproject("sub2")
+
+        and: "task does not yet exist"
+        assert !subProject1.extensions.findByName(extensionName)
+        assert !subProject2.extensions.findByName(extensionName)
+
+        and:
+        SnykRootPluginExtension rootExtension = project.extensions.findByName(extensionName) as SnykRootPluginExtension
+
+        when:
+        if (registerType == "Iterable<Project>") {
+            rootExtension.registerProject([subProject1, subProject2])
+        } else if (registerType == "registerAllSubProjects") {
+            rootExtension.registerAllSubProjects()
+        }
+
+        then:
+        def extension1 = subProject1.extensions.findByName(extensionName)
+        extensionType.isInstance extension1
+        !notOfType.isInstance(extension1)
+
+        def extension2 = subProject2.extensions.findByName(extensionName)
+        extensionType.isInstance extension2
+        !notOfType.isInstance(extension2)
+
+        where:
+        extensionName | extensionType       | notOfType               | registerType
+        'snyk'        | SnykPluginExtension | SnykRootPluginExtension | "Iterable<Project>"
+        'snyk'        | SnykPluginExtension | SnykRootPluginExtension | "registerAllSubProjects"
+    }
+
+    @Unroll
+    def "Creates the '#extensionName' extension with type #extensionType for registered project #projectType #projectFile"() {
+        given: "a project with snyk plugin added"
+        project.plugins.apply(PLUGIN_NAME)
+
+        and: "a project file"
+        def _projectFile = new File(projectDir, projectFile)
+        if (projectType == "file") {
+            _projectFile.parentFile.mkdirs()
+            _projectFile.text = "Something"
+        } else {
+            _projectFile.mkdirs()
+        }
+
+        and: "task does not yet exist"
+        assert !project.extensions.findByName(extensionName)
+
+        and:
+        SnykRootPluginExtension rootExtension = project.extensions.findByName("snyk") as SnykRootPluginExtension
+
+        when:
+        rootExtension.registerProject(_projectFile)
+
+        then:
+        def extension = project.extensions.findByName(extensionName)
+        extensionType.isInstance extension
+        !notOfType.isInstance(extension)
+
+        where:
+        projectFile           | extensionName              | projectType | extensionType       | notOfType
+        "test.properties"     | 'snyk.test.properties'     | "file"      | SnykPluginExtension | SnykRootPluginExtension
+        "foo/test.properties" | 'snyk.foo.test.properties' | "file"      | SnykPluginExtension | SnykRootPluginExtension
+        "test"                | 'snyk.test'                | "dir"       | SnykPluginExtension | SnykRootPluginExtension
+        "foo/test"            | 'snyk.foo.test'            | "dir"       | SnykPluginExtension | SnykRootPluginExtension
+    }
+
+    @Unroll
+    def "throws #exceptionType when registered project #projectType does not exist"() {
+        given: "a project with snyk plugin added"
+        project.plugins.apply(PLUGIN_NAME)
+
+        and:
+        SnykRootPluginExtension rootExtension = project.extensions.findByName("snyk") as SnykRootPluginExtension
+
+        when:
+        rootExtension.registerProject(new File(projectDir, projectFile))
+
+        then:
+        thrown(exceptionType)
+
+        where:
+        projectFile       | projectType
+        "test.properties" | "file"
+        "foo"             | "dir"
+        exceptionType = FileNotFoundException
+    }
+
+    @Unroll
+    def "Creates task #taskName with type #taskType for registered project #projectType #projectFile"() {
+        given: "a project with snyk plugin added"
+        project.plugins.apply(PLUGIN_NAME)
+
+        and: "a project file"
+        def _projectFile = new File(projectDir, projectFile)
+        if (projectType == "file") {
+            _projectFile.parentFile.mkdirs()
+            _projectFile.text = "Something"
+        } else {
+            _projectFile.mkdirs()
+        }
+
+        and: "task does not yet exist"
+        assert !project.tasks.findByName(taskName)
+
+        and:
+        SnykRootPluginExtension rootExtension = project.extensions.findByName("snyk") as SnykRootPluginExtension
+
+        when:
+        rootExtension.registerProject(_projectFile)
+
+        then:
+        def task = project.tasks.findByName(taskName)
+        taskType.isInstance(task)
+
+        where:
+        projectFile           | taskName                          | projectType | taskType
+        "test.properties"     | "snykTest.test.properties"        | "file"      | Test
+        "test"                | "snykTest.test"                   | "dir"       | Test
+        "foo/test.properties" | "snykTest.foo.test.properties"    | "file"      | Test
+        "bar/test"            | "snykTest.bar.test"               | "dir"       | Test
+        "test.properties"     | "snykMonitor.test.properties"     | "file"      | Monitor
+        "test"                | "snykMonitor.test"                | "dir"       | Monitor
+        "baz/test.properties" | "snykMonitor.baz.test.properties" | "file"      | Monitor
+        "foo/test"            | "snykMonitor.foo.test"            | "dir"       | Monitor
+        "test.properties"     | "snykReport.test.properties"      | "file"      | Report
+        "test"                | "snykReport.test"                 | "dir"       | Report
+        "bar/test.properties" | "snykReport.bar.test.properties"  | "file"      | Report
+        "baz/test"            | "snykReport.baz.test"             | "dir"       | Report
     }
 }


### PR DESCRIPTION
## Description

This patch allows to register gradle sub projects, package files or directories as snyk projects. The usecase is to have more control over the invocation of the snyk cli when dealing with a gradle multi project. The `--all-projects` or `--all-sub-projects` flag of the `snyk` cli has issues if one want to control the project name or if one needs to set custom tags/properties per project.

This is where project registration comes into play. It allows to configure a whole multiproject from the root build.gradle file. A potential configuration could look like this:

```groovy
snyk {
    projectLifecycle = "production"
    projectEnvironment = "internal"
    projectBusinessCriticality = "high"
    projectTags = ["team": "someTeam", "component": "lib"]
    strategies.set(['monitor_check', "report_check", 'monitor_publish'])
    failOn = "all"
    severityThreshold = "high"

    registerProject(file("paket.dependencies")) {
        projectTags.put("platform", ".Net")
        projectEnvironment = "distributed"
    }

    registerProject(project.findProject(":Shared")) {
        projectTags.put("platform", "universal")
    }

    registerProject(project.subprojects.findAll {it.path.startsWith(":android:")}) {
        projectTags.put("platform", "android")
        projectTags.put("component", "android-lib")
        projectEnvironment = "mobile"
    }
}
```

For this to work I created a handfull of new classes and interfaces. The biggest impact is the split between a root snyk extension and a normal snyk extension. Internally I create new extensions for each registered project. The extensions will be added either on the to be registered sub project or will be added in root with a unique name. I don't want allow that these extensions contain the methods to register projects on their own again to limit the fail vector of misconfiguration. So the root snyk extension which is added when applying the plugin will be the only extension which contains the newly added register methods.

For each registered project the new `ProjectRegistrationHandler` will create an extension and the three base tasks (`test`, `monitor`, `report`). Depending on the type of project to be added (gradle subproject or file) the tasks will be either added on the sub projects or the root project with a unique name based on the file name.

The conventions will cascade up to the root extensions only for a few exceptions.

Example: the newly registered `snykTest` task for the sub project `sub1` will be created in `sub1` and named `snykTest`.
Or fully qualified `:sub1:snykTest`.
The property token will be bound to the property token of registered `SnykPluginExtension` named `snyk` in `sub1`. The property token of the `SnykPluginExtension` in `sub1` will be bound to the `snyk` extension in the root project.

```
:sub1:snykTest#token -> :sub1:snyk#token -> :snyk#token
```

Obviously this can be all reconfigured. For this I added overloads to all register methods to pass either an `Action` object or a configuration closure.

Because of the name mangling needed to add multiple snykTest tasks to the root project it might become hard to configure specific properties for a given task only. This is the reason why I added new task accessors to the extension.

```groovy
snyk {
    snykMonitor {    // configure the snykMonitor task in root
        projectTags = ...
    }

    registerProject(project.findProject("sub")) {
       snykMonitor { // configure the snykMonitor task in :sub project
           token = ...
       }
    }

    registerProject(file('project.properties')) {
       snykMonitor { // configure the snykMonitor task for `project.properties` project file
           token = ...
       }
    }
}
```

The extensions add accessors for
* snykTest
* snykMonitor
* snykReport

Changes
=======

* ![ADD] snyk project register support

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"