### PR TITLE
Fix missing debug flag binding

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/snyk/tasks/SnykCheckBaseIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/snyk/tasks/SnykCheckBaseIntegrationSpec.groovy
@@ -384,7 +384,7 @@ abstract class SnykCheckBaseIntegrationSpec<T extends SnykTask> extends SnykTask
         setSnykWrapper(true, subjectUnderTestName)
 
         and: "a set of properties being set onto the task"
-        if (setter.concat("file")){
+        if (setter.concat("file")) {
             createFile(mockFile)
         }
         def platformProjectDir = projectDir.path.split("\\\\").join("/")
@@ -436,6 +436,7 @@ abstract class SnykCheckBaseIntegrationSpec<T extends SnykTask> extends SnykTask
         "yarnWorkspaces=true"                                                 | "--yarn-workspaces"
         "skipUnresolved=true"                                                 | "--skip-unresolved"
         "command=${wrap("foobar")}"                                           | "--command=foobar"
+        "debug=true"                                                          | "-d"
 
         expected = flags.toString().empty ? commandName : "${commandName} ${flags}"
         mockFile = "foo.bar"

--- a/src/integrationTest/groovy/wooga/gradle/snyk/tasks/SnykTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/snyk/tasks/SnykTaskIntegrationSpec.groovy
@@ -111,7 +111,7 @@ abstract class SnykTaskIntegrationSpec<T extends SnykTask> extends SnykIntegrati
         ${object}.snykPath=${wrapValueBasedOnType(wrapperPath, Directory)}
         """.stripIndent()
 
-        if (setDummyToken){
+        if (setDummyToken) {
             buildFile << """
         ${object}.token=${wrapValueBasedOnType("foobar", String)}
         """.stripIndent()
@@ -205,7 +205,7 @@ abstract class SnykTaskIntegrationSpec<T extends SnykTask> extends SnykIntegrati
 
         when:
         def firstRun = runTasks(subjectUnderTestName)
-        def secondRun  = runTasks(subjectUnderTestName)
+        def secondRun = runTasks(subjectUnderTestName)
 
         then:
         firstRun.success
@@ -213,6 +213,4 @@ abstract class SnykTaskIntegrationSpec<T extends SnykTask> extends SnykIntegrati
         secondRun.success
         !secondRun.wasUpToDate(subjectUnderTestName)
     }
-
-
 }

--- a/src/main/groovy/wooga/gradle/snyk/cli/CommonArgumentSpec.groovy
+++ b/src/main/groovy/wooga/gradle/snyk/cli/CommonArgumentSpec.groovy
@@ -19,11 +19,40 @@ package wooga.gradle.snyk.cli
 import com.wooga.gradle.BaseSpec
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.options.Option
+import wooga.gradle.OptionMapper
+import wooga.gradle.snyk.cli.options.CommonOption
 
-trait CommonArgumentSpec extends BaseSpec {
+trait CommonArgumentSpec extends BaseSpec implements OptionMapper<CommonOption> {
+
+    @Internal
+    ProviderFactory getProviderFactory() {
+        getProviders()
+    }
+
+    @Override
+    String getOption(CommonOption option) {
+        def value = null
+
+        switch (option) {
+            case CommonOption.debug:
+                if (debug.present && debug.get()) {
+                    value = true
+                }
+                break
+        }
+
+        if (value != null) {
+            def output = option.compose(value)
+            return output
+        }
+        null
+    }
+
     private final Property<Boolean> insecure = objects.property(Boolean)
 
     @Input

--- a/src/main/groovy/wooga/gradle/snyk/cli/options/CommonOption.groovy
+++ b/src/main/groovy/wooga/gradle/snyk/cli/options/CommonOption.groovy
@@ -1,0 +1,25 @@
+package wooga.gradle.snyk.cli.options
+
+import wooga.gradle.OptionBuilder
+import wooga.gradle.OptionSpec
+import wooga.gradle.snyk.cli.SnykBooleanOption
+
+enum CommonOption implements OptionSpec {
+    debug("-d", new SnykBooleanOption())
+
+    private String flag
+    private OptionBuilder builder
+
+    String getFlag() {
+        flag
+    }
+
+    OptionBuilder getBuilder() {
+        builder
+    }
+
+    CommonOption(String flag, OptionBuilder builder) {
+        this.flag = flag
+        this.builder = builder
+    }
+}

--- a/src/main/groovy/wooga/gradle/snyk/tasks/Monitor.groovy
+++ b/src/main/groovy/wooga/gradle/snyk/tasks/Monitor.groovy
@@ -16,9 +16,10 @@
 
 package wooga.gradle.snyk.tasks
 
+
+import wooga.gradle.snyk.cli.commands.MonitorProjectCommandSpec
 import wooga.gradle.snyk.cli.options.CommonOption
 import wooga.gradle.snyk.cli.options.MonitorOption
-import wooga.gradle.snyk.cli.commands.MonitorProjectCommandSpec
 import wooga.gradle.snyk.cli.options.ProjectOption
 import wooga.gradle.snyk.cli.options.TestOption
 

--- a/src/main/groovy/wooga/gradle/snyk/tasks/Monitor.groovy
+++ b/src/main/groovy/wooga/gradle/snyk/tasks/Monitor.groovy
@@ -16,7 +16,7 @@
 
 package wooga.gradle.snyk.tasks
 
-
+import wooga.gradle.snyk.cli.options.CommonOption
 import wooga.gradle.snyk.cli.options.MonitorOption
 import wooga.gradle.snyk.cli.commands.MonitorProjectCommandSpec
 import wooga.gradle.snyk.cli.options.ProjectOption
@@ -33,6 +33,7 @@ class Monitor extends SnykTask implements MonitorProjectCommandSpec {
     @Override
     void addMainOptions(List<String> args) {
         args.add("monitor")
+        args.addAll(getMappedOptions(this, CommonOption))
         args.addAll(getMappedOptions(this, MonitorOption))
         args.addAll(getMappedOptions(this, TestOption))
         args.addAll(getMappedOptions(this, ProjectOption))

--- a/src/main/groovy/wooga/gradle/snyk/tasks/Test.groovy
+++ b/src/main/groovy/wooga/gradle/snyk/tasks/Test.groovy
@@ -75,5 +75,6 @@ class Test extends SnykTask implements TestProjectCommandSpec {
         args.addAll(getMappedOptions(this, CommonOption))
         args.addAll(getMappedOptions(this, TestOption))
         args.addAll(getMappedOptions(this, ProjectOption))
+        args.addAll(getMappedOptions(this, CommonOption))
     }
 }

--- a/src/main/groovy/wooga/gradle/snyk/tasks/Test.groovy
+++ b/src/main/groovy/wooga/gradle/snyk/tasks/Test.groovy
@@ -19,6 +19,7 @@ package wooga.gradle.snyk.tasks
 import org.gradle.api.tasks.Nested
 import org.gradle.internal.reflect.Instantiator
 import wooga.gradle.snyk.cli.commands.TestProjectCommandSpec
+import wooga.gradle.snyk.cli.options.CommonOption
 import wooga.gradle.snyk.cli.options.ProjectOption
 import wooga.gradle.snyk.cli.options.TestOption
 import wooga.gradle.snyk.report.SnykReports
@@ -71,6 +72,7 @@ class Test extends SnykTask implements TestProjectCommandSpec {
     @Override
     void addMainOptions(List<String> args) {
         args.add("test")
+        args.addAll(getMappedOptions(this, CommonOption))
         args.addAll(getMappedOptions(this, TestOption))
         args.addAll(getMappedOptions(this, ProjectOption))
     }


### PR DESCRIPTION
## Description

I saw that we totally forgot to bind the `debug` property to `-d` flag for the snyk cli

## Changes

* ![FIX] missing binding of `debug` property to `-d` flag

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"