### PR TITLE
Fix path passed to --file needs to be relative

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/snyk/tasks/SnykCheckBaseIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/snyk/tasks/SnykCheckBaseIntegrationSpec.groovy
@@ -410,7 +410,7 @@ abstract class SnykCheckBaseIntegrationSpec<T extends SnykTask> extends SnykTask
         "remoteRepoUrl=${wrap("foo.bar/pancakes")}"                           | "--remote-repo-url"
         "includeDevelopmentDependencies=true"                                 | "--dev"
         "orgName=${wrap("PANCAKES")}"                                         | "--org=PANCAKES"
-        "packageFile = ${wrapValueBasedOnType("#projectDir#/foo.bar", File)}" | "--file=${new File("#projectDir#/foo.bar").path}"
+        "packageFile = ${wrapValueBasedOnType("#projectDir#/foo.bar", File)}" | "--file=foo.bar"
         "ignorePolicy=true"                                                   | "--ignore-policy"
         "showVulnerablePaths=${wrapValueBasedOnType("all", String)}"          | "--show-vulnerable-paths=all"
         "targetReference=${wrapValueBasedOnType("foobar", String)}"           | "--target-reference"

--- a/src/main/groovy/wooga/gradle/snyk/cli/commands/TestProjectCommandSpec.groovy
+++ b/src/main/groovy/wooga/gradle/snyk/cli/commands/TestProjectCommandSpec.groovy
@@ -19,6 +19,7 @@ package wooga.gradle.snyk.cli.commands
 
 import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.internal.file.FileOperations
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
@@ -33,10 +34,17 @@ import wooga.gradle.snyk.cli.SeverityThresholdOption
 import wooga.gradle.snyk.cli.VulnerablePathsOption
 import wooga.gradle.snyk.cli.options.TestOption
 
+import javax.inject.Inject
+
 /**
  * Provides properties for the Test command
  */
 trait TestProjectCommandSpec extends ProjectCommandSpec implements OptionMapper<TestOption> {
+
+    @Inject
+    FileOperations getFileOperations() {
+        throw new UnsupportedOperationException();
+    }
 
     @Override
     String getOption(TestOption option) {
@@ -99,7 +107,7 @@ trait TestProjectCommandSpec extends ProjectCommandSpec implements OptionMapper<
 
             case TestOption.packageFile:
                 if (packageFile.present) {
-                    value = packageFile.asFile.get()
+                    value = new File(fileOperations.relativePath(packageFile.asFile.get()))
                 }
                 break
 


### PR DESCRIPTION
## Description

The path to the `--file` flag is used to calcualte the snyk project id. It should be relative so the project id becomes deterministic.

I used gradle internals to calculate the relative file path from the given file.

## Changes

* ![FIX] path passed to `--file` argument needs to be relative

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"