### PR TITLE
Improve Report task herachy

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/snyk/SnykStrategyIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/snyk/SnykStrategyIntegrationSpec.groovy
@@ -4,6 +4,7 @@ import com.wooga.gradle.test.PropertyLocation
 import com.wooga.gradle.test.PropertyQueryTaskWriter
 import spock.lang.Unroll
 import wooga.gradle.snyk.tasks.Monitor
+import wooga.gradle.snyk.tasks.Report
 import wooga.gradle.snyk.tasks.Test
 
 import static com.wooga.gradle.test.PropertyUtils.*
@@ -126,6 +127,9 @@ class SnykStrategyIntegrationSpec extends SnykIntegrationSpec {
         snykTaskName  | snykTaskNames                         | snykTaskType | hookTaskName | strategy
         "snykMonitor" | ["snykMonitor2", "snykMonitorCustom"] | Monitor      | "check"      | ["monitor_check"]
         "snykTest"    | ["snykTest2", "snykTestCustom"]       | Test         | "check"      | ["test_check"]
+        "snykReport"  | ["snykReport2", "snykReportCustom"]   | Report       | "check"      | ["report_check"]
         "snykMonitor" | ["snykMonitor2", "snykMonitorCustom"] | Monitor      | "publish"    | ["monitor_publish"]
+        "snykTest"    | ["snykTest2", "snykTestCustom"]       | Test         | "publish"    | ["test_publish"]
+        "snykReport"  | ["snykReport2", "snykReportCustom"]   | Report       | "publish"    | ["report_publish"]
     }
 }

--- a/src/main/groovy/wooga/gradle/snyk/tasks/Report.groovy
+++ b/src/main/groovy/wooga/gradle/snyk/tasks/Report.groovy
@@ -1,7 +1,12 @@
 package wooga.gradle.snyk.tasks
-
-
-class Report extends Test {
+/**
+ * The {@code Report} task has the same functionality as {@link Test} task type.
+ * The main difference is that the {@code Report} task never fails and will
+ * create json reports by default.
+ *
+ * @see wooga.gradle.snyk.tasks.Test
+ */
+class Report extends SnykCheckBase {
 
     Report() {
         reports.json.enabled = true

--- a/src/main/groovy/wooga/gradle/snyk/tasks/SnykCheckBase.groovy
+++ b/src/main/groovy/wooga/gradle/snyk/tasks/SnykCheckBase.groovy
@@ -1,0 +1,58 @@
+package wooga.gradle.snyk.tasks
+
+import org.gradle.api.tasks.Nested
+import org.gradle.internal.reflect.Instantiator
+import wooga.gradle.snyk.cli.commands.TestProjectCommandSpec
+import wooga.gradle.snyk.cli.options.CommonOption
+import wooga.gradle.snyk.cli.options.ProjectOption
+import wooga.gradle.snyk.cli.options.TestOption
+import wooga.gradle.snyk.report.SnykReports
+import wooga.gradle.snyk.report.SnykReportsImpl
+
+import javax.inject.Inject
+
+abstract class SnykCheckBase extends SnykTask implements TestProjectCommandSpec {
+    @Inject
+    protected Instantiator getInstantiator() {
+        throw new UnsupportedOperationException()
+    }
+
+    private SnykReports reports
+
+    @Nested
+    SnykReports getReports() {
+        reports
+    }
+
+    @Inject
+    SnykCheckBase() {
+        reports = instantiator.newInstance(SnykReportsImpl.class, this)
+
+        reports.sarif.outputLocation.convention(project.layout.buildDirectory.file(new File(this.temporaryDir, "report.sarif").absolutePath))
+        reports.json.outputLocation.convention(project.layout.buildDirectory.file(new File(this.temporaryDir, "report.json").absolutePath))
+
+        sarifOutputPath.convention(providers.provider({
+            if (reports.sarif.enabled) {
+                return reports.sarif.outputLocation.get()
+            }
+            null
+        }))
+
+        jsonOutputPath.convention(providers.provider({
+            if (reports.json.enabled) {
+                return reports.json.outputLocation.get()
+            }
+            null
+        }))
+    }
+
+
+    @Override
+    void addMainOptions(List<String> args) {
+        args.add("test")
+        args.addAll(getMappedOptions(this, CommonOption))
+        args.addAll(getMappedOptions(this, TestOption))
+        args.addAll(getMappedOptions(this, ProjectOption))
+        args.addAll(getMappedOptions(this, CommonOption))
+    }
+}

--- a/src/main/groovy/wooga/gradle/snyk/tasks/Test.groovy
+++ b/src/main/groovy/wooga/gradle/snyk/tasks/Test.groovy
@@ -15,66 +15,10 @@
  */
 
 package wooga.gradle.snyk.tasks
-
-import org.gradle.api.tasks.Nested
-import org.gradle.internal.reflect.Instantiator
-import wooga.gradle.snyk.cli.commands.TestProjectCommandSpec
-import wooga.gradle.snyk.cli.options.CommonOption
-import wooga.gradle.snyk.cli.options.ProjectOption
-import wooga.gradle.snyk.cli.options.TestOption
-import wooga.gradle.snyk.report.SnykReports
-import wooga.gradle.snyk.report.SnykReportsImpl
-
-import javax.inject.Inject
-
 /**
  * The snyk test command checks projects for open source vulnerabilities and license issues.
  * The test command tries to auto-detect supported manifest files with dependencies and test those.
  * (https://docs.snyk.io/features/snyk-cli/commands/test)
  */
-class Test extends SnykTask implements TestProjectCommandSpec {
-
-    @Inject
-    protected Instantiator getInstantiator() {
-        throw new UnsupportedOperationException()
-    }
-
-    private SnykReports reports
-
-    @Nested
-    SnykReports getReports() {
-        reports
-    }
-
-    @Inject
-    Test() {
-        reports = instantiator.newInstance(SnykReportsImpl.class, this)
-
-        reports.sarif.outputLocation.convention(project.layout.buildDirectory.file(new File(this.temporaryDir, "report.sarif").absolutePath))
-        reports.json.outputLocation.convention(project.layout.buildDirectory.file(new File(this.temporaryDir, "report.json").absolutePath))
-
-        sarifOutputPath.convention(providers.provider({
-            if (reports.sarif.enabled) {
-                return reports.sarif.outputLocation.get()
-            }
-            null
-        }))
-
-        jsonOutputPath.convention(providers.provider({
-            if (reports.json.enabled) {
-                return reports.json.outputLocation.get()
-            }
-            null
-        }))
-    }
-
-
-    @Override
-    void addMainOptions(List<String> args) {
-        args.add("test")
-        args.addAll(getMappedOptions(this, CommonOption))
-        args.addAll(getMappedOptions(this, TestOption))
-        args.addAll(getMappedOptions(this, ProjectOption))
-        args.addAll(getMappedOptions(this, CommonOption))
-    }
+class Test extends SnykCheckBase {
 }


### PR DESCRIPTION
## Description

When I introduced the `Report` type I made the decission to extend it from `Test` since it has the same interface and basic implementation. The issue is, if I want to filter for all `Test` tasks with

```groovy
def allTests = project.tasks.withType(Test)
```

then I also have all `Report` tasks in the list. I broke this link with this patch and reimplemented the concrete type in an abstract class. I also defined some more strategies to hook these tasks executions into a task run with the following additions:

* `test_publish`
* `report_publish`

Changes
=======

* ![IMPROVE] `Report` task herachy by breaking `Test` class from `Report` class
* ![ADD] new strategy definitions for report and test

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"