### PR TITLE
Add SnykToHtmlInstall task

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/snyk/tasks/SnykInstallBaseIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/snyk/tasks/SnykInstallBaseIntegrationSpec.groovy
@@ -1,0 +1,372 @@
+package wooga.gradle.snyk.tasks
+
+import com.wooga.gradle.test.PropertyQueryTaskWriter
+import org.apache.commons.codec.digest.DigestUtils
+import org.mockserver.integration.ClientAndServer
+import org.mockserver.logging.MockServerLogger
+import org.mockserver.socket.tls.KeyStoreFactory
+import spock.lang.Unroll
+import spock.util.environment.RestoreSystemProperties
+import wooga.gradle.snyk.SnykInstallSpec
+import wooga.gradle.snyk.SnykIntegrationSpec
+
+import javax.net.ssl.HttpsURLConnection
+import java.lang.reflect.ParameterizedType
+import java.nio.file.Files
+
+import static com.wooga.gradle.PlatformUtils.windows
+import static com.wooga.gradle.test.PropertyUtils.toProviderSet
+import static com.wooga.gradle.test.PropertyUtils.toSetter
+import static org.mockserver.integration.ClientAndServer.startClientAndServer
+import static org.mockserver.model.HttpOverrideForwardedRequest.forwardOverriddenRequest
+import static org.mockserver.model.HttpRequest.request
+import static org.mockserver.stop.Stop.stopQuietly
+
+abstract class SnykInstallBaseIntegrationSpec<T extends SnykInstallSpec> extends SnykIntegrationSpec {
+
+    /**Snyk cache for tests where the downloading process itself doesn't matter*/
+    private static final File CACHED_SNYK_DIR = File.createTempDir("atlas-snyk", "installTest")
+
+    Class<T> getSubjectUnderTestClass() {
+        if (!_sutClass) {
+            try {
+                this._sutClass = (Class<T>) ((ParameterizedType) this.getClass().getGenericSuperclass())
+                        .getActualTypeArguments()[0];
+            }
+            catch (Exception e) {
+                this._sutClass = (Class<T>) SnykTask
+            }
+        }
+        _sutClass
+    }
+    private Class<T> _sutClass
+
+    @Override
+    String getSubjectUnderTestName() {
+        "${subjectUnderTestClass.simpleName.uncapitalize()}Test"
+    }
+
+    @Override
+    String getSubjectUnderTestTypeName() {
+        subjectUnderTestClass.getTypeName()
+    }
+
+    def setup() {
+        environmentVariables.set("SNYK_TOKEN", System.getenv("ATLAS_SNYK_INTEGRATION_TOKEN"))
+        buildFile << """
+        
+        task $subjectUnderTestName(type: ${subjectUnderTestTypeName})
+        """.stripIndent()
+    }
+
+    abstract List<InstallTestModel> getInstallTestVersions()
+
+    @Unroll("installs valid snyk executable file for version #version to target directory")
+    def "installs given snyk version on target directory for macOS"() {
+        given: "a snyk install task with specified parameters"
+        appendToSubjectTask(buildGradleSnykInstallTask(version, new File(projectDir, targetDir), executableName ?: "snyk"))
+
+        when:
+        runTasksSuccessfully(subjectUnderTestName)
+
+        then:
+        def expectedSnykFile = new File(projectDir, expectedSnykExec.path)
+        expectedSnykFile.file
+        DigestUtils.sha256Hex(expectedSnykFile.bytes) == expectedChecksum
+        def process = Runtime.runtime.exec([expectedSnykFile.absolutePath, "--help"] as String[])
+        process.waitFor() == 0
+
+        where:
+        version << installTestVersions.collect { it.version }
+        targetDir << installTestVersions.collect { it.targetDir }
+        executableName << installTestVersions.collect { it.executableName }
+        expectedSnykExec << installTestVersions.collect { it.expectedSnykExec }
+        expectedChecksum << installTestVersions.collect { it.expectedChecksum }
+    }
+
+    def "doesn't redownload executable if identical version already exists on installationDir"() {
+        given: "a snyk install task"
+        appendToSubjectTask(buildGradleSnykInstallTask(version, CACHED_SNYK_DIR, executeableName))
+
+        and: "a already existing snyk"
+        def targetSnykFile = new File(CACHED_SNYK_DIR, "${isWindows() ? "${executeableName}.exe" : executeableName}")
+        if (!targetSnykFile.file) {
+            runTasksSuccessfully(subjectUnderTestName)
+        }
+        assert targetSnykFile.file
+
+        when:
+        def originalCreationTS = targetSnykFile.lastModified()
+        runTasksSuccessfully(subjectUnderTestName)
+
+        then:
+        def snykFile = new File(targetSnykFile.path)
+        originalCreationTS == snykFile.lastModified()
+
+        where:
+        version = installTestVersions[0].version
+        executeableName = installTestVersions[0].executableName
+    }
+
+    def "task is up-to-date when latest fetches the same version"() {
+        given: "a snyk install task with specified parameters"
+        appendToSubjectTask(buildGradleSnykInstallTask("latest", new File(projectDir, "snyk"), "snyk"))
+
+        when:
+        def firstRunResult = runTasksSuccessfully(subjectUnderTestName)
+
+        then:
+        firstRunResult.wasExecuted(subjectUnderTestName)
+        !firstRunResult.wasUpToDate(subjectUnderTestName)
+        !firstRunResult.wasSkipped(subjectUnderTestName)
+
+        when:
+        def secondRunResult = runTasksSuccessfully(subjectUnderTestName)
+        then:
+        secondRunResult.wasExecuted(subjectUnderTestName)
+        secondRunResult.wasUpToDate(subjectUnderTestName)
+        !secondRunResult.wasSkipped(subjectUnderTestName)
+    }
+
+    @Unroll("can set property #property with cli option #cliOption")
+    def "can set property via cli option"() {
+        given: "a task to read back the value"
+        def query = new PropertyQueryTaskWriter("${subjectUnderTestName}.${property}")
+        query.write(buildFile)
+
+        and: "set minimal needed properties"
+        appendToSubjectTask("""
+        installationDir = file('build/installs')
+        executableName = 'snyk'
+        version = '1.0.0'
+        """.stripIndent())
+
+        and: "tasks to execute"
+        def tasks = [subjectUnderTestName, cliOption]
+        if (rawValue != _) {
+            tasks.add(value)
+        }
+        tasks.add(query.taskName)
+
+        and: "disable subject under test to no fail"
+        appendToSubjectTask("enabled=false")
+
+
+        when:
+        def result = runTasksSuccessfully(*tasks)
+
+        then:
+        query.matches(result, expectedValue)
+
+        where:
+        property          | cliOption            | rawValue                      | returnValue | type
+        "installationDir" | "--installation-dir" | osPath("/path/to/installDir") | _           | "CLIString"
+        "executableName"  | "--executable-name"  | "my-custom-snyk"              | _           | "CLIString"
+        "version"         | "--version"          | "22.11.33"                    | _           | "CLIString"
+
+        value = wrapValueBasedOnType(rawValue, type, wrapValueFallback)
+        expectedValue = returnValue == _ ? rawValue : returnValue
+    }
+
+    @Unroll("can set property #property with #method and type #type")
+    def "can set property SnykTask"() {
+        given: "a task to read back the value"
+        def query = new PropertyQueryTaskWriter("${subjectUnderTestName}.${property}")
+        query.write(buildFile)
+
+        and: "a set property"
+        appendToSubjectTask("${method}($value)")
+
+        when:
+        def result = runTasksSuccessfully(query.taskName)
+
+        then:
+        query.matches(result, expectedValue)
+
+        where:
+        property          | method                  | rawValue                       | returnValue | type
+        "executableName"  | toProviderSet(property) | "snyk1"                        | _           | "String"
+        "executableName"  | toProviderSet(property) | "snyk2"                        | _           | "Provider<String>"
+        "executableName"  | toSetter(property)      | "snyk3"                        | _           | "String"
+        "executableName"  | toSetter(property)      | "snyk4"                        | _           | "Provider<String>"
+
+        "version"         | toProviderSet(property) | "11.22.1"                      | _           | "String"
+        "version"         | toProviderSet(property) | "11.22.2"                      | _           | "Provider<String>"
+        "version"         | toSetter(property)      | "11.22.3"                      | _           | "String"
+        "version"         | toSetter(property)      | "11.22.4"                      | _           | "Provider<String>"
+
+        "installationDir" | toProviderSet(property) | osPath("/path/to/installDir1") | _           | "File"
+        "installationDir" | toProviderSet(property) | osPath("/path/to/installDir2") | _           | "Provider<Directory>"
+        "installationDir" | toSetter(property)      | osPath("/path/to/installDir3") | _           | "File"
+        "installationDir" | toSetter(property)      | osPath("/path/to/installDir4") | _           | "Provider<Directory>"
+        "installationDir" | property                | osPath("/path/to/installDir5") | _           | "String"
+
+        value = wrapValueBasedOnType(rawValue, type, wrapValueFallback)
+        expectedValue = returnValue == _ ? rawValue : returnValue
+    }
+
+    @Unroll
+    def "help prints commandline flag '#commandlineFlag' description"() {
+        when:
+        def result = runTasksSuccessfully("help", "--task", subjectUnderTestName)
+
+        then:
+        result.standardOutput.contains("Description")
+        result.standardOutput.contains("Group")
+
+        result.standardOutput.contains(commandlineFlag)
+
+        where:
+        commandlineFlag      | _
+        "--executable-name"  | _
+        "--installation-dir" | _
+        "--version"          | _
+    }
+
+    def buildGradleSnykInstallTask(String snykVersion, File installationDir, String executableName = null) {
+        return """
+            version = "${snykVersion}"
+            installationDir = ${wrapValueBasedOnType(installationDir, File)}
+            executableName = ${wrapValueBasedOnType(executableName ?: "snyk", String)}
+        """
+    }
+
+    static class InstallTestModel {
+        String version
+        String targetDir
+        String executableName
+        File expectedSnykExec
+        String expectedChecksum
+
+        InstallTestModel(String version, String targetDir, String executableName, File expectedSnykExec, String expectedChecksum) {
+            this.version = version
+            this.targetDir = targetDir
+            this.executableName = executableName
+            if (isWindows() && !expectedSnykExec.name.endsWith(".exe")) {
+                this.expectedSnykExec = new File(expectedSnykExec.path + ".exe")
+            } else {
+                this.expectedSnykExec = expectedSnykExec
+            }
+            this.expectedChecksum = expectedChecksum
+        }
+
+        static InstallTestModel model(String version, String targetDir, String executableName, File expectedSnykExec, String expectedChecksum) {
+            new InstallTestModel(version, targetDir, executableName, expectedSnykExec, expectedChecksum)
+        }
+
+        static InstallTestModel model(String version, String targetDir, String executableName, File expectedSnykExec) {
+            new InstallTestModel(version, targetDir, executableName, expectedSnykExec, null)
+        }
+
+    }
+
+    protected void forwardAllSnykRequests(ClientAndServer mockServer) {
+        mockServer
+                .when(
+                        request()
+                )
+                .forward(
+                        forwardOverriddenRequest(
+                                request()
+                                        .withHeader("Host", "static.snyk.io")
+                        )
+                )
+    }
+
+    abstract String downloadRequestPath(String version, String file)
+
+    void mockVersionRequests(ClientAndServer mockServer, String version, String mockVersion, List<String> files) {
+        files.each { String file ->
+            mockServer
+                    .when(
+                            request()
+                                    .withPath(downloadRequestPath(version, file))
+                    )
+                    .forward(
+                            forwardOverriddenRequest(
+                                    request()
+                                            .withPath(downloadRequestPath(mockVersion, file))
+                                            .withHeader("Host", "static.snyk.io")
+                            )
+                    )
+        }
+    }
+
+    void clearMockVersionRequests(ClientAndServer mockServer, String version, List<String> files) {
+        files.each { String file ->
+            mockServer.clear(request().withPath(downloadRequestPath(version, file)))
+        }
+    }
+
+    abstract List<String> getVersionFiles()
+
+    static ensureVersionPrefix(String versionTag, String prefix = "v") {
+        if (versionTag != "latest" && !versionTag.startsWith(prefix)) {
+            return prefix + versionTag
+        }
+        versionTag
+    }
+
+    @RestoreSystemProperties
+    def "auto updates preinstalled version when version is set to 'latest'"() {
+        given: "a snyk install task with specified parameters"
+        appendToSubjectTask(buildGradleSnykInstallTask(version, new File(projectDir, installDir), executableName))
+
+        and: "a proxy server to mock a specific result"
+        // ensure all connection using HTTPS will use the SSL context defined by
+        // MockServer to allow dynamically generated certificates to be accepted
+        HttpsURLConnection.setDefaultSSLSocketFactory(new KeyStoreFactory(new MockServerLogger()).sslContext().getSocketFactory());
+        def mockServer = startClientAndServer()
+
+        System.setProperty("static.snyk.io.baseUrl", "https://localhost:${mockServer.getPort()}")
+        mockServer.reset()
+
+        and: "forward latest call to old release json"
+        mockVersionRequests(mockServer, version, mockVersion, files)
+        and: "a proxy setup for any path not /cli/latest/release.json"
+        forwardAllSnykRequests(mockServer)
+        //Opens a webpage with logs and other useful information about the current proxy/mock server
+        //mockServer.openUI()
+
+        and: "a future snyk file"
+        def expectedSnykFile = new File(projectDir, "${installDir}/${normalizedExecutableName}")
+        assert !expectedSnykFile.exists()
+
+        when: "a first run to install snyk"
+        runTasksSuccessfully(subjectUnderTestName)
+
+        then:
+        expectedSnykFile.exists()
+        DigestUtils.sha256Hex(Files.newInputStream(expectedSnykFile.toPath())) == mockChecksum
+        "${expectedSnykFile.absolutePath} --help".execute().waitFor() == 0
+
+
+        when: "latest returns latest version"
+        //clear the forward
+        clearMockVersionRequests(mockServer, version, files)
+        mockServer.clear(request())
+        forwardAllSnykRequests(mockServer)
+
+        def result = runTasksSuccessfully(subjectUnderTestName)
+
+        then:
+        result.wasExecuted(subjectUnderTestName)
+        !result.wasUpToDate(subjectUnderTestName)
+        expectedSnykFile.file
+        expectedSnykFile.canExecute()
+        DigestUtils.sha256Hex(Files.newInputStream(expectedSnykFile.toPath())) != mockChecksum
+        "${expectedSnykFile.absolutePath} --help".execute().waitFor() == 0
+
+        cleanup:
+        stopQuietly(mockServer)
+
+        where:
+        version = 'latest'
+        files = versionFiles
+        mockVersion = installTestVersions.last().version
+        mockChecksum = installTestVersions.last().expectedChecksum
+        executableName = "snykExecutable"
+        normalizedExecutableName = isWindows() ? "${executableName}.exe" : executableName
+        installDir = "build/snyk"
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/snyk/tasks/SnykInstallIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/snyk/tasks/SnykInstallIntegrationSpec.groovy
@@ -1,41 +1,36 @@
 package wooga.gradle.snyk.tasks
 
-import com.wooga.gradle.PlatformUtils
-import com.wooga.gradle.test.PropertyQueryTaskWriter
-import org.apache.commons.codec.digest.DigestUtils
-import org.junit.Rule
-import org.junit.rules.TestRule
-import org.mockserver.integration.ClientAndServer
-import org.mockserver.logging.MockServerLogger
-import org.mockserver.socket.tls.KeyStoreFactory
-import spock.lang.IgnoreIf
-import spock.lang.Unroll
-import spock.util.environment.RestoreSystemProperties
-import wooga.gradle.snyk.SnykIntegrationSpec
+
 import wooga.gradle.snyk.SnykPlugin
 
-import javax.net.ssl.HttpsURLConnection
-
 import static com.wooga.gradle.PlatformUtils.*
-import static com.wooga.gradle.test.PropertyUtils.toProviderSet
-import static com.wooga.gradle.test.PropertyUtils.toSetter
-import static org.mockserver.integration.ClientAndServer.startClientAndServer
-import static org.mockserver.model.HttpOverrideForwardedRequest.forwardOverriddenRequest
-import static org.mockserver.model.HttpRequest.request
-import static org.mockserver.stop.Stop.stopQuietly
+import static wooga.gradle.snyk.tasks.SnykInstallBaseIntegrationSpec.InstallTestModel.model
 
-class SnykInstallIntegrationSpec extends SnykIntegrationSpec {
+class SnykInstallIntegrationSpec extends SnykInstallBaseIntegrationSpec<SnykInstall> {
 
-    /**Snyk cache for tests where the downloading process itself doesn't matter*/
-    private static final File CACHED_SNYK_DIR = File.createTempDir("atlas-snyk", "installTest")
+    List<InstallTestModel> getInstallTestVersions() {
+        List<InstallTestModel> data = []
+        data << model("1.839.0", "snyk", "snyk", new File("snyk/snyk"))
+        data << model("1.838.0", "snyk", "snyk", new File("snyk/snyk"))
+        data << model("1.837.0", "snuk", "snek", new File("snuk/snek"))
 
-    String subjectUnderTestName = "installTest"
-    String subjectUnderTestTypeName = SnykInstall.name
+        if (isMac()) {
+            data[0].expectedChecksum = "f3e5e31def231eb04d910c3cf0723c922c858fa1e9d1f2d1cdbd9099be878897"
+            data[1].expectedChecksum = "33f65baa53a3d9f0b1406225ed215e802be94bd429c5141ef21cc5ce16daedb6"
+            data[2].expectedChecksum = "b467c382ea2ed0763db8e07b36a4724ff4c7b705587f616025aca3077d07ee95"
+        }
+        if (isWindows()) {
+            data[0].expectedChecksum = "6559946fa8270ad498d58fb5e75d0c55d014a70ac59383ea8440baefe2b2be7d"
+            data[1].expectedChecksum = "5178479ca737963048baf84bc151901d30047bee0e67b6d836766d22c981c016"
+            data[2].expectedChecksum = "b2ae120eea9872843a1090a3b3f5e602ef7c185aa49b974834880bc376ed59a8"
+        }
 
-    def setup() {
-        buildFile << """
-            project.tasks.register("${subjectUnderTestName}", ${subjectUnderTestTypeName})
-        """
+        if (isLinux()) {
+            data[0].expectedChecksum = "5cd779adbef19c3c9982f01b672d5bd0e0005943a9dbb7038f8be772f70d1ddb"
+            data[1].expectedChecksum = "c52363013e21413c65e6b839c5ff5355c3c4ffc12b168e9c365a63b0c09ea4c8"
+            data[2].expectedChecksum = "e9ff8be02250a7b0bd85e8bde8ecb7939eb79c08a1c8ab59b3d0f1ef65d006df"
+        }
+        data
     }
 
     def "install snyk using plugin defaults"() {
@@ -67,300 +62,14 @@ class SnykInstallIntegrationSpec extends SnykIntegrationSpec {
         process.waitFor() == 0
     }
 
-    @RestoreSystemProperties
-    def "auto updates preinstalled version when version is set to 'latest'"() {
-        given: "a snyk install task with specified parameters"
-        appendToSubjectTask(buildGradleSnykInstallTask(version, new File(projectDir, installDir), executableName))
-        jvmArguments << "-Xms512m -Xmx1g"
-
-        and: "a proxy server to mock a specific result"
-        // ensure all connection using HTTPS will use the SSL context defined by
-        // MockServer to allow dynamically generated certificates to be accepted
-        HttpsURLConnection.setDefaultSSLSocketFactory(new KeyStoreFactory(new MockServerLogger()).sslContext().getSocketFactory());
-        def mockServer = startClientAndServer()
-
-        System.setProperty("static.snyk.io.baseUrl", "https://localhost:${mockServer.getPort()}")
-        mockServer.reset()
-
-        and: "forward latest call to old release json"
-        mockServer
-                .when(
-                        request()
-                                .withPath("/cli/${version}/release.json")
-                )
-                .forward(
-                        forwardOverriddenRequest(
-                                request()
-                                        .withPath("/cli/v${mockVersion}/release.json")
-                                        .withHeader("Host", "static.snyk.io")
-                        )
-                )
-
-        and: "a proxy setup for any path not /cli/latest/release.json"
-        proxyAllSnykRequests(mockServer)
-        //Opens a webpage with logs and other useful information about the current proxy/mock server
-        //mockServer.openUI()
-
-        and: "a future snyk file"
-        def expectedSnykFile = new File(projectDir, "${installDir}/${normalizedExecutableName}")
-        assert !expectedSnykFile.exists()
-
-        when: "a first run to install snyk"
-        runTasksSuccessfully(subjectUnderTestName)
-
-        then:
-        expectedSnykFile.exists()
-        fetchVersion(expectedSnykFile) == mockVersion
-
-        when: "latest returns latest version"
-        //clear the forward
-        mockServer.clear(request().withPath("/cli/${version}/release.json"))
-        mockServer.clear(request())
-        proxyAllSnykRequests(mockServer)
-
-        def result = runTasksSuccessfully(subjectUnderTestName)
-
-        then:
-        result.wasExecuted(subjectUnderTestName)
-        !result.wasUpToDate(subjectUnderTestName)
-        expectedSnykFile.file
-        expectedSnykFile.canExecute()
-        fetchVersion(expectedSnykFile)
-        fetchVersion(expectedSnykFile) != mockVersion
-
-        cleanup:
-        stopQuietly(mockServer)
-
-        where:
-        version  | mockVersion | executableName | installDir
-        "latest" | "1.837.0"   | "snyk"         | "build/snyk"
-        normalizedExecutableName = isWindows() ? "${executableName}.exe" : executableName
+    @Override
+    String downloadRequestPath(String version, String file) {
+        "/cli/${ensureVersionPrefix(version)}/${file}"
     }
 
-    private proxyAllSnykRequests(ClientAndServer mockServer) {
-        mockServer
-                .when(
-                        request()
-                )
-                .forward(
-                        forwardOverriddenRequest(
-                                request()
-                                        .withHeader("Host", "static.snyk.io")
-                        )
-                )
-    }
-
-    def "task is up-to-date when latest fetches the same version"() {
-        given: "a snyk install task with specified parameters"
-        appendToSubjectTask(buildGradleSnykInstallTask("latest", new File(projectDir, "snyk"), "snyk"))
-
-        when:
-        def firstRunResult = runTasksSuccessfully(subjectUnderTestName)
-
-        then:
-        firstRunResult.wasExecuted(subjectUnderTestName)
-        !firstRunResult.wasUpToDate(subjectUnderTestName)
-        !firstRunResult.wasSkipped(subjectUnderTestName)
-
-        when:
-        def secondRunResult = runTasksSuccessfully(subjectUnderTestName)
-        then:
-        secondRunResult.wasExecuted(subjectUnderTestName)
-        secondRunResult.wasUpToDate(subjectUnderTestName)
-        !secondRunResult.wasSkipped(subjectUnderTestName)
-    }
-
-    @IgnoreIf({ !isMac() })
-    @Unroll("installs valid snyk file from version #version on target directory for macOS")
-    def "installs given snyk version on target directory for macOS"() {
-        given: "a snyk install task with specified parameters"
-        appendToSubjectTask(buildGradleSnykInstallTask(version, new File(projectDir, targetDir), executableName))
-
-        when:
-        runTasksSuccessfully(subjectUnderTestName)
-
-        then:
-        def expectedSnykFile = new File(projectDir, expectedSnykExec.path)
-        expectedSnykFile.file
-        DigestUtils.sha256Hex(expectedSnykFile.bytes) == expectedChecksum
-        def process = Runtime.runtime.exec([expectedSnykFile.absolutePath, "--version"] as String[])
-        process.waitFor() == 0
-
-        where:
-        version    | targetDir | executableName | expectedSnykExec      | expectedChecksum
-        "v1.839.0" | "snyk"    | null           | new File("snyk/snyk") | "f3e5e31def231eb04d910c3cf0723c922c858fa1e9d1f2d1cdbd9099be878897"
-        "v1.838.0" | "snyk"    | "snyk"         | new File("snyk/snyk") | "33f65baa53a3d9f0b1406225ed215e802be94bd429c5141ef21cc5ce16daedb6"
-        "v1.837.0" | "snuk"    | "snek"         | new File("snuk/snek") | "b467c382ea2ed0763db8e07b36a4724ff4c7b705587f616025aca3077d07ee95"
-    }
-
-
-    @IgnoreIf({ !isLinux() })
-    @Unroll("installs valid snyk file from version #version on target directory for linux")
-    def "installs given snyk version on target directory for linux"() {
-        given: "a snyk install task with specified parameters"
-        appendToSubjectTask(buildGradleSnykInstallTask(version, new File(projectDir, targetDir), executableName))
-
-        when:
-        runTasksSuccessfully(subjectUnderTestName)
-
-        then:
-        def expectedSnykFile = new File(projectDir, expectedSnykExec.path)
-        expectedSnykFile.file
-        DigestUtils.sha256Hex(expectedSnykFile.bytes) == expectedChecksum
-        def process = Runtime.runtime.exec([expectedSnykFile.absolutePath, "--version"] as String[])
-        process.waitFor() == 0
-
-        where:
-        version    | targetDir | executableName | expectedSnykExec      | expectedChecksum
-        "v1.839.0" | "snyk"    | null           | new File("snyk/snyk") | "5cd779adbef19c3c9982f01b672d5bd0e0005943a9dbb7038f8be772f70d1ddb"
-        "v1.838.0" | "snyk"    | "snuk"         | new File("snyk/snuk") | "c52363013e21413c65e6b839c5ff5355c3c4ffc12b168e9c365a63b0c09ea4c8"
-        "v1.837.0" | "snuk"    | "snek"         | new File("snuk/snek") | "e9ff8be02250a7b0bd85e8bde8ecb7939eb79c08a1c8ab59b3d0f1ef65d006df"
-    }
-
-    @IgnoreIf({ !isWindows() })
-    @Unroll("installs valid snyk file from version #version on target directory for windows")
-    def "installs given snyk version on target directory for windows"() {
-        given: "a snyk install task with specified parameters"
-        appendToSubjectTask(buildGradleSnykInstallTask(version, new File(projectDir, targetDir), executableName))
-
-        when:
-        runTasksSuccessfully(subjectUnderTestName)
-
-        then:
-        def expectedSnykFile = new File(projectDir, expectedSnykExec.path)
-        expectedSnykFile.file
-        DigestUtils.sha256Hex(expectedSnykFile.bytes) == expectedChecksum
-        def process = Runtime.runtime.exec([expectedSnykFile.absolutePath, "--version"] as String[])
-        process.waitFor() == 0
-
-        where:
-        version    | targetDir | executableName | expectedSnykExec          | expectedChecksum
-        "v1.839.0" | "snyk"    | null           | new File("snyk/snyk.exe") | "6559946fa8270ad498d58fb5e75d0c55d014a70ac59383ea8440baefe2b2be7d"
-        "v1.838.0" | "snyk"    | "snuk"         | new File("snyk/snuk.exe") | "5178479ca737963048baf84bc151901d30047bee0e67b6d836766d22c981c016"
-        "v1.837.0" | "snuk"    | "snek"         | new File("snuk/snek.exe") | "b2ae120eea9872843a1090a3b3f5e602ef7c185aa49b974834880bc376ed59a8"
-    }
-
-    def "doesn't redownload snyk if identical version already exists on installationDir"() {
-        given: "a snyk install task"
-        appendToSubjectTask(buildGradleSnykInstallTask("v1.839.0", CACHED_SNYK_DIR, "snyk"))
-
-        and: "a already existing snyk"
-        def targetSnykFile = new File(CACHED_SNYK_DIR, "${isWindows() ? "snyk.exe" : "snyk"}")
-        if (!targetSnykFile.file) {
-            runTasksSuccessfully(subjectUnderTestName)
-        }
-        assert targetSnykFile.file
-
-        when:
-        def originalCreationTS = targetSnykFile.lastModified()
-        runTasksSuccessfully(subjectUnderTestName)
-
-        then:
-        def snykFile = new File(targetSnykFile.path)
-        originalCreationTS == snykFile.lastModified()
-    }
-
-    @Unroll("can set property #property with cli option #cliOption")
-    def "can set property via cli option"() {
-        given: "a task to read back the value"
-        def query = new PropertyQueryTaskWriter("${subjectUnderTestName}.${property}")
-        query.write(buildFile)
-
-        and: "set minimal needed properties"
-        appendToSubjectTask("""
-        installationDir = file('build/installs')
-        executableName = 'snyk'
-        version = '1.0.0'
-        """.stripIndent())
-
-        and: "tasks to execute"
-        def tasks = [subjectUnderTestName, cliOption]
-        if (rawValue != _) {
-            tasks.add(value)
-        }
-        tasks.add(query.taskName)
-
-        and: "disable subject under test to no fail"
-        appendToSubjectTask("enabled=false")
-
-
-        when:
-        def result = runTasksSuccessfully(*tasks)
-
-        then:
-        query.matches(result, expectedValue)
-
-        where:
-        property          | cliOption            | rawValue                      | returnValue | type
-        "installationDir" | "--installation-dir" | osPath("/path/to/installDir") | _           | "CLIString"
-        "executableName"  | "--executable-name"  | "my-custom-snyk"              | _           | "CLIString"
-        "version"         | "--version"          | "22.11.33"                    | _           | "CLIString"
-
-        value = wrapValueBasedOnType(rawValue, type, wrapValueFallback)
-        expectedValue = returnValue == _ ? rawValue : returnValue
-    }
-
-    @Unroll("can set property #property with #method and type #type")
-    def "can set property SnykTask"() {
-        given: "a task to read back the value"
-        def query = new PropertyQueryTaskWriter("${subjectUnderTestName}.${property}")
-        query.write(buildFile)
-
-        and: "a set property"
-        appendToSubjectTask("${method}($value)")
-
-        when:
-        def result = runTasksSuccessfully(query.taskName)
-
-        then:
-        query.matches(result, expectedValue)
-
-        where:
-        property          | method                  | rawValue                       | returnValue | type
-        "executableName"  | toProviderSet(property) | "snyk1"                        | _           | "String"
-        "executableName"  | toProviderSet(property) | "snyk2"                        | _           | "Provider<String>"
-        "executableName"  | toSetter(property)      | "snyk3"                        | _           | "String"
-        "executableName"  | toSetter(property)      | "snyk4"                        | _           | "Provider<String>"
-
-        "version"         | toProviderSet(property) | "11.22.1"                      | _           | "String"
-        "version"         | toProviderSet(property) | "11.22.2"                      | _           | "Provider<String>"
-        "version"         | toSetter(property)      | "11.22.3"                      | _           | "String"
-        "version"         | toSetter(property)      | "11.22.4"                      | _           | "Provider<String>"
-
-        "installationDir" | toProviderSet(property) | osPath("/path/to/installDir1") | _           | "File"
-        "installationDir" | toProviderSet(property) | osPath("/path/to/installDir2") | _           | "Provider<Directory>"
-        "installationDir" | toSetter(property)      | osPath("/path/to/installDir3") | _           | "File"
-        "installationDir" | toSetter(property)      | osPath("/path/to/installDir4") | _           | "Provider<Directory>"
-        "installationDir" | property                | osPath("/path/to/installDir5") | _           | "String"
-
-        value = wrapValueBasedOnType(rawValue, type, wrapValueFallback)
-        expectedValue = returnValue == _ ? rawValue : returnValue
-    }
-
-    @Unroll
-    def "help prints commandline flag '#commandlineFlag' description"() {
-        when:
-        def result = runTasksSuccessfully("help", "--task", subjectUnderTestName)
-
-        then:
-        result.standardOutput.contains("Description")
-        result.standardOutput.contains("Group")
-
-        result.standardOutput.contains(commandlineFlag)
-
-        where:
-        commandlineFlag      | _
-        "--executable-name"  | _
-        "--installation-dir" | _
-        "--version"          | _
-    }
-
-    def buildGradleSnykInstallTask(String snykVersion, File installationDir, String executableName = null) {
-        return """
-            version = "${snykVersion}"
-            installationDir = ${wrapValueBasedOnType(installationDir, File)}
-            executableName = ${wrapValueBasedOnType(executableName ?: "snyk", String)}
-        """
+    @Override
+    List<String> getVersionFiles() {
+        ["release.json"]
     }
 
     static File getGradleUserHome() {

--- a/src/integrationTest/groovy/wooga/gradle/snyk/tasks/SnykToHtmlInstallIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/snyk/tasks/SnykToHtmlInstallIntegrationSpec.groovy
@@ -1,0 +1,53 @@
+package wooga.gradle.snyk.tasks
+
+
+import static com.wooga.gradle.PlatformUtils.*
+import static wooga.gradle.snyk.tasks.SnykInstallBaseIntegrationSpec.InstallTestModel.model
+
+class SnykToHtmlInstallIntegrationSpec extends SnykInstallBaseIntegrationSpec<SnykToHtmlInstall> {
+
+    List<InstallTestModel> getInstallTestVersions() {
+        List<InstallTestModel> data = []
+        data << model("2.2.2", "snyk", "s2html", new File("snyk/s2html"))
+        data << model("2.2.1", "snyk", "snyk2html", new File("snyk/snyk2html"))
+        data << model("2.0.0", "snuk", "snyk-to-html", new File("snuk/snyk-to-html"))
+
+        if (isMac()) {
+            data[0].expectedChecksum = "feb674cf2d72832e24600b03ac75108dfeae99760754048d04db6f6248b5aaa2"
+            data[1].expectedChecksum = "c584b76e718773af76378b40604ebfb901be4afafa33ce7b7890e5df431924de"
+            data[2].expectedChecksum = "e52321bc5306b141837fdcdb508ae7a79d83c10bf711f5d0b3b9f098e7e26d86"
+        }
+        if (isWindows()) {
+            data[0].expectedChecksum = "850c9d402f4d50765aaee49107f3dcc24962f45e012ef92c85589351317fa759"
+            data[1].expectedChecksum = "5599ecc29f0b834f7673f723ef72f96c1d54d1ed9e394772aaf33eb9aa8f26f8"
+            data[2].expectedChecksum = "43e497b135ed646d8ef640a14dc3e6531d185a936e59f1fba329780178538b75"
+        }
+
+        if (isLinux()) {
+            data[0].expectedChecksum = "8bfb615f624072a283bdf2c1d4a8f1a6ac8f2e828daf55d1b6e19676d3ac409f"
+            data[1].expectedChecksum = "2e443ffe87d9bc4512e8ba2d37c13a5425d5e8de985f8ce95920903f13b16b93"
+            data[2].expectedChecksum = "daa8fc1fe0863d7ec4f3bf82eb3ce9a19ed4957ef054cf6d890d6164839c5585"
+        }
+        data
+    }
+
+    @Override
+    String downloadRequestPath(String version, String file) {
+        "/snyk-to-html/${ensureVersionPrefix(version)}/${file}"
+    }
+
+    @Override
+    List<String> getVersionFiles() {
+        def files = []
+        if (isMac()) {
+            files << "snyk-to-html-macos" << "snyk-to-html-macos.sha256"
+        }
+        if (isWindows()) {
+            files << "snyk-to-html-win.exe" << "snyk-to-html-win.exe.sha256"
+        }
+        if (isLinux()) {
+            files << "snyk-to-html-linux" << "snyk-to-html-linux.sha256"
+        }
+        files
+    }
+}

--- a/src/main/groovy/wooga/gradle/snyk/SnykInstallSpec.groovy
+++ b/src/main/groovy/wooga/gradle/snyk/SnykInstallSpec.groovy
@@ -34,7 +34,7 @@ trait SnykInstallSpec extends BaseSpec {
     }
 
     @Option(option = "installation-dir", description = """
-    The directory to install snyk cli to.
+    The directory to install to.
     """)
     void setInstallationDir(String value) {
         installationDir.set(new File(value))
@@ -44,7 +44,7 @@ trait SnykInstallSpec extends BaseSpec {
 
     @Internal
     @Option(option = "executable-name", description = """
-    The name of the snyk executable without .exe after installation.
+    The name of the executable without .exe after installation.
     """)
     Property<String> getExecutableName() {
         executableName
@@ -62,7 +62,7 @@ trait SnykInstallSpec extends BaseSpec {
 
     @Input
     @Option(option = "version", description = """
-    The version of snyk to install.
+    The version to install.
     """)
     Property<String> getVersion() {
         version

--- a/src/main/groovy/wooga/gradle/snyk/tasks/SnykInstall.groovy
+++ b/src/main/groovy/wooga/gradle/snyk/tasks/SnykInstall.groovy
@@ -1,36 +1,39 @@
 package wooga.gradle.snyk.tasks
 
-
 import com.wooga.gradle.PlatformUtils
 import groovy.json.JsonSlurper
-import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.OutputFile
-import org.gradle.api.tasks.TaskAction
-import wooga.gradle.snyk.SnykInstallSpec
-import wooga.gradle.snyk.tasks.internal.CachedGroliphantDownloader
-import wooga.gradle.snyk.tasks.internal.Downlader
 import wooga.gradle.snyk.tasks.internal.SnykDownloadAsset
 
-class SnykInstall extends DefaultTask implements SnykInstallSpec {
+class SnykInstall extends SnykInstallBase {
 
     static String getReleaseJsonUrl(String version) {
         def baseUrl = System.getProperty("static.snyk.io.baseUrl", "https://static.snyk.io")
         "${baseUrl}/cli/${version}/release.json"
     }
 
-    @OutputFile
     final Provider<RegularFile> snykExecutable
-
-    private final Provider<Map<String, SnykDownloadAsset>> snykReleasesProvider
+    final Provider<Map<String, SnykDownloadAsset>> snykReleasesProvider
 
     private final Provider<String> versionToInstall
 
     @Input
     Provider<String> getVersionToInstall() {
         versionToInstall
+    }
+
+    @Override
+    protected String getPlatformSpecificFileName() {
+        if (PlatformUtils.isWindows()) {
+            return "snyk-win.exe"
+        } else if (PlatformUtils.isMac()) {
+            return "snyk-macos"
+        } else if (PlatformUtils.isLinux()) {
+            return "snyk-linux"
+        }
+        throw new UnsupportedOperationException("Current OS do not have an available snyk binary for download")
     }
 
     SnykInstall() {
@@ -55,30 +58,6 @@ class SnykInstall extends DefaultTask implements SnykInstallSpec {
         }.memoize())
     }
 
-    @TaskAction
-    void run() {
-        def downloader = new CachedGroliphantDownloader(project)
-        downloadRelease(snykExecutable.get().asFile, snykReleasesProvider.get(), downloader)
-    }
-
-    private static File downloadRelease(File fullExecutablePath, Map<String, SnykDownloadAsset> snykReleases, Downlader downloader) {
-        if (PlatformUtils.isWindows()) {
-            return snykReleases["snyk-win.exe"].download(fullExecutablePath, downloader)
-        } else if (PlatformUtils.isMac()) {
-            return snykReleases["snyk-macos"].download(fullExecutablePath, downloader)
-        } else if (PlatformUtils.isLinux()) {
-            return snykReleases["snyk-linux"].download(fullExecutablePath, downloader)
-        }
-        throw new UnsupportedOperationException("Current OS do not have an available snyk binary for download")
-    }
-
-    private static ensureVersionPrefix(String versionTag, String prefix = "v") {
-        if (!versionTag.startsWith(prefix)) {
-            return prefix + versionTag
-        }
-        versionTag
-    }
-
     private static Map<String, SnykDownloadAsset> fetchSnykReleases(String versionTag) {
         def releasesURL = getReleaseJsonUrl(ensureVersionPrefix(versionTag))
         def result = new JsonSlurper().parse(new URL(releasesURL)) as Map
@@ -90,12 +69,5 @@ class SnykInstall extends DefaultTask implements SnykInstallSpec {
             return [(name): new SnykDownloadAsset(name, actualVersion,
                     new URL(assetData.url as String), assetData.sha256 as String)]
         } as Map<String, SnykDownloadAsset>
-    }
-
-    private static String normalizeExecutableByOS(String executableName) {
-        if (PlatformUtils.isWindows()) {
-            return executableName.endsWith(".exe") ? executableName : "${executableName}.exe"
-        }
-        return executableName
     }
 }

--- a/src/main/groovy/wooga/gradle/snyk/tasks/SnykInstallBase.groovy
+++ b/src/main/groovy/wooga/gradle/snyk/tasks/SnykInstallBase.groovy
@@ -1,0 +1,49 @@
+package wooga.gradle.snyk.tasks
+
+import com.wooga.gradle.PlatformUtils
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFile
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import wooga.gradle.snyk.SnykInstallSpec
+import wooga.gradle.snyk.tasks.internal.CachedGroliphantDownloader
+import wooga.gradle.snyk.tasks.internal.SnykDownloadAsset
+
+abstract class SnykInstallBase extends DefaultTask implements SnykInstallSpec {
+
+    static String getReleaseJsonUrl(String version) {
+        def baseUrl = System.getProperty("static.snyk.io.baseUrl", "https://static.snyk.io")
+        "${baseUrl}/cli/${version}/release.json"
+    }
+
+    @OutputFile
+    abstract Provider<RegularFile> getSnykExecutable()
+
+    @Internal
+    abstract Provider<Map<String, SnykDownloadAsset>> getSnykReleasesProvider()
+
+    @TaskAction
+    void run() {
+        def downloader = new CachedGroliphantDownloader(project)
+        snykReleasesProvider.get()[platformSpecificFileName].download(snykExecutable.get().asFile, downloader)
+    }
+
+    @Internal
+    protected abstract String getPlatformSpecificFileName()
+
+    static ensureVersionPrefix(String versionTag, String prefix = "v") {
+        if (versionTag != "latest" && !versionTag.startsWith(prefix)) {
+            return prefix + versionTag
+        }
+        versionTag
+    }
+
+    static String normalizeExecutableByOS(String executableName) {
+        if (PlatformUtils.isWindows()) {
+            return executableName.endsWith(".exe") ? executableName : "${executableName}.exe"
+        }
+        return executableName
+    }
+}

--- a/src/main/groovy/wooga/gradle/snyk/tasks/SnykToHtmlInstall.groovy
+++ b/src/main/groovy/wooga/gradle/snyk/tasks/SnykToHtmlInstall.groovy
@@ -1,0 +1,64 @@
+package wooga.gradle.snyk.tasks
+
+import com.wooga.gradle.PlatformUtils
+import org.gradle.api.file.RegularFile
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
+import wooga.gradle.snyk.tasks.internal.SnykDownloadAsset
+
+class SnykToHtmlInstall extends SnykInstallBase {
+
+    static String getDownloadUrl(String version, String file) {
+        if (version != 'latest') {
+            version = ensureVersionPrefix(version)
+        }
+        def baseUrl = System.getProperty("static.snyk.io.baseUrl", "https://static.snyk.io")
+        "${baseUrl}/snyk-to-html/${version}/${file}"
+    }
+
+    @OutputFile
+    final Provider<RegularFile> snykExecutable
+    final Provider<Map<String, SnykDownloadAsset>> snykReleasesProvider
+
+    private final Provider<String> versionChecksum
+
+    @Input
+    Provider<String> getVersionChecksum() {
+        versionChecksum
+    }
+
+    SnykToHtmlInstall() {
+        this.snykExecutable = installationDir.zip(executableName) {
+            dir, fileName -> dir.file(normalizeExecutableByOS(fileName))
+        }
+
+        this.versionChecksum = version.map({String version ->
+            def checksumURL = new URL(getDownloadUrl(version, platformSpecificFileName + '.sha256'))
+            def checksumOutput = new ByteArrayOutputStream()
+            def checksum = checksumURL.withInputStream { i -> checksumOutput << i }.toString()
+            checksum.trim().split(" ")[0]
+        })
+
+        this.snykReleasesProvider = version.zip(versionChecksum, { String version, String checksum ->
+            [(platformSpecificFileName): new SnykDownloadAsset(
+                    platformSpecificFileName,
+                    version,
+                    new URL(getDownloadUrl(version, platformSpecificFileName)),
+                    checksum
+            )]
+        }.memoize())
+    }
+
+    @Override
+    protected String getPlatformSpecificFileName() {
+        if (PlatformUtils.isWindows()) {
+            return "snyk-to-html-win.exe"
+        } else if (PlatformUtils.isMac()) {
+            return "snyk-to-html-macos"
+        } else if (PlatformUtils.isLinux()) {
+            return "snyk-to-html-linux"
+        }
+        throw new UnsupportedOperationException("Current OS do not have an available snyk-to-html binary for download")
+    }
+}

--- a/src/main/groovy/wooga/gradle/snyk/tasks/internal/CachedGroliphantDownloader.groovy
+++ b/src/main/groovy/wooga/gradle/snyk/tasks/internal/CachedGroliphantDownloader.groovy
@@ -5,6 +5,8 @@ import org.gradle.api.Project
 import org.gradle.wrapper.IDownload
 import org.ysb33r.grolifant.internal.v4.downloader.Downloader
 
+import java.nio.file.Files
+
 class CachedGroliphantDownloader implements Downlader {
 
     private final Closure<IDownload> downloaderFactory
@@ -40,7 +42,7 @@ class CachedGroliphantDownloader implements Downlader {
     }
 
     private static boolean checksum(File file, String sha256) {
-        def actualSum = DigestUtils.sha256Hex(file.bytes)
+        def actualSum = DigestUtils.sha256Hex(Files.newInputStream(file.toPath()))
         return sha256 == null || actualSum == sha256
     }
 }


### PR DESCRIPTION
## Description

This patch adds a new installer task for the `snyk-to-html` utility. The tool can be used to convert `json` reports generated by `snyk test` to `html` report pages. This is a preparation patch to add an installer task. The task is not yet wired in the plugin. I mainly added the functionality to download the tool. The basic setup on snyk side is very similar to the cli tool. There is a slight exception that this tool won't be published with a `releases.json` file. But the whole download setup is so generic that I created an abstract base class which the new install task and the `SnykInstall` task both extend from. I did the same for the integration tests.

Changes
=======

* ![ADD] `SnykToHtmlInstall` task

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
