### PR TITLE
Fix snyk token handling

### DIFF
--- a/src/main/groovy/wooga/gradle/snyk/cli/SnykTaskSpec.groovy
+++ b/src/main/groovy/wooga/gradle/snyk/cli/SnykTaskSpec.groovy
@@ -30,6 +30,7 @@ trait SnykTaskSpec extends BaseSpec {
     private final Property<String> token = objects.property(String)
 
     @Input
+    @Optional
     Property<String> getToken() {
         token
     }

--- a/src/main/groovy/wooga/gradle/snyk/tasks/SnykTask.groovy
+++ b/src/main/groovy/wooga/gradle/snyk/tasks/SnykTask.groovy
@@ -64,10 +64,17 @@ abstract class SnykTask extends DefaultTask
         def _arguments = arguments.get()
         def _workingDir = workingDirectory.getOrNull()
         def _executable
+        Map<String, ?> _environment = [:]
         if (snykPath.present) {
             _executable = snykPath.file(executableName).get().asFile.path
         } else {
             _executable = executableName.get()
+        }
+
+        //TODO: handle custom environment variables with gradle-commons when implemented.
+        // see: https://github.com/wooga/gradle-commons/issues/14
+        if(token.present) {
+            _environment.put("SNYK_TOKEN", token.get())
         }
 
         if (logFile.present){
@@ -81,6 +88,7 @@ abstract class SnykTask extends DefaultTask
                 exec.with {
                     executable _executable
                     args = _arguments
+                    environment(_environment)
                     ignoreExitValue = true
                     standardOutput = getOutputStream(logFile.asFile.getOrNull())
                     errorOutput = getOutputStream(logFile.asFile.getOrNull())


### PR DESCRIPTION
## Description

During testing I saw that snyk monitor only works by coincidence since we ask for the same environment property name `SNYK_TOKEN` as a convention to set the `token` property. The token property is actually not needed as a common or base property since only commands whi interact with snyk backend need a token to authenticate. I left it in `SnykTaskSpec` for the moment since we lack a generic way to describe custom environment variables from properties similar to commandline arguments. A feature request is filed for [wooga/gradle-commons#14].

I did a very minimalistic implemenation to make sure that the token value is passed as environment variable to `snyk` cli.

Changes
=======

* ![FIX] `snyk` token handling

[wooga/gradle-commons#14]: https://github.com/wooga/gradle-commons/issues/14

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
