### PR TITLE
Improve Closure parameter with type annotations

### DIFF
--- a/src/main/groovy/wooga/gradle/snyk/SnykPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/snyk/SnykPluginExtension.groovy
@@ -16,6 +16,8 @@
 
 package wooga.gradle.snyk
 
+import groovy.transform.stc.ClosureParams
+import groovy.transform.stc.FromString
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.file.Directory
@@ -45,7 +47,7 @@ trait SnykPluginExtension implements
         snykTest.configure(action)
     }
 
-    void snykTest(Closure configure) {
+    void snykTest(@ClosureParams(value = FromString.class, options = ["wooga.gradle.snyk.tasks.Test"]) Closure configure) {
         snykTest.configure(ConfigureUtil.configureUsing(configure))
     }
 
@@ -53,7 +55,7 @@ trait SnykPluginExtension implements
         snykMonitor.configure(action)
     }
 
-    void snykMonitor(Closure configure) {
+    void snykMonitor(@ClosureParams(value = FromString.class, options = ["wooga.gradle.snyk.tasks.Monitor"]) Closure configure) {
         snykMonitor.configure(ConfigureUtil.configureUsing(configure))
     }
 
@@ -61,7 +63,7 @@ trait SnykPluginExtension implements
         snykReport.configure(action)
     }
 
-    void snykReport(Closure configure) {
+    void snykReport(@ClosureParams(value = FromString.class, options = ["wooga.gradle.snyk.tasks.Report"]) Closure configure) {
         snykReport.configure(ConfigureUtil.configureUsing(configure))
     }
 

--- a/src/main/groovy/wooga/gradle/snyk/SnykRootPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/snyk/SnykRootPluginExtension.groovy
@@ -16,6 +16,8 @@
 
 package wooga.gradle.snyk
 
+import groovy.transform.stc.ClosureParams
+import groovy.transform.stc.FromString
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.provider.Property
@@ -32,7 +34,7 @@ trait SnykRootPluginExtension implements SnykPluginExtension, SnykInstallSpec, S
         action.execute(snykToHtml)
     }
 
-    void snykToHtml(Closure configure) {
+    void snykToHtml(@ClosureParams(value = FromString.class, options = ["wooga.gradle.snyk.SnykToHtmlPluginExtension"]) Closure configure) {
         snykToHtml(ConfigureUtil.configureUsing(configure))
     }
 
@@ -42,7 +44,7 @@ trait SnykRootPluginExtension implements SnykPluginExtension, SnykInstallSpec, S
         snykInstall.configure(action)
     }
 
-    void snykInstall(Closure configure) {
+    void snykInstall(@ClosureParams(value = FromString.class, options = ["wooga.gradle.snyk.tasks.SnykInstall"]) Closure configure) {
         snykInstall.configure(ConfigureUtil.configureUsing(configure))
     }
 
@@ -98,7 +100,7 @@ trait SnykRootPluginExtension implements SnykPluginExtension, SnykInstallSpec, S
      * @param action a configuration closure which gets with the newly added [snyk] extension.
      * @return a {@link SnykPluginExtension} object
      */
-    SnykPluginExtension registerProject(File project, Closure configure) {
+    SnykPluginExtension registerProject(File project, @ClosureParams(value = FromString.class, options = ["wooga.gradle.snyk.SnykPluginExtension"]) Closure configure) {
         registerProject(project, ConfigureUtil.configureUsing(configure))
     }
 
@@ -138,7 +140,7 @@ trait SnykRootPluginExtension implements SnykPluginExtension, SnykInstallSpec, S
      * @param configure configuration closure which gets with the newly added [snyk] extension on the subproject
      * @return a {@link SnykPluginExtension} object
      */
-    SnykPluginExtension registerProject(Project subProject, Closure configure) {
+    SnykPluginExtension registerProject(Project subProject, @ClosureParams(value = FromString.class, options = ["wooga.gradle.snyk.SnykPluginExtension"]) Closure configure) {
         registerProject(subProject, ConfigureUtil.configureUsing(configure))
     }
 
@@ -171,7 +173,7 @@ trait SnykRootPluginExtension implements SnykPluginExtension, SnykInstallSpec, S
      * @param subProjects the projects to register
      * @param configure a configuration closure which gets called for each provided subproject
      */
-    void registerProject(Iterable<Project> subProjects, Closure configure) {
+    void registerProject(Iterable<Project> subProjects, @ClosureParams(value = FromString.class, options = ["wooga.gradle.snyk.SnykPluginExtension"]) Closure configure) {
         subProjects.each {
             registerProject(it, configure)
         }
@@ -214,7 +216,7 @@ trait SnykRootPluginExtension implements SnykPluginExtension, SnykInstallSpec, S
      *
      * @see SnykRootPluginExtension.#registerProject
      */
-    void registerAllSubProjects(Closure configure) {
+    void registerAllSubProjects(@ClosureParams(value = FromString.class, options = ["wooga.gradle.snyk.SnykPluginExtension"]) Closure configure) {
         /* Why not calling `registerAllSubProjects(ConfigureUtil.configureUsing(configure))`?
            This would put the scope of the closure into the wrong extension. We either let
            the actual working implementation of `registerProject(Project, Closure)` convert it,

--- a/src/main/groovy/wooga/gradle/snyk/SnykToHtmlPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/snyk/SnykToHtmlPluginExtension.groovy
@@ -16,6 +16,8 @@
 
 package wooga.gradle.snyk
 
+import groovy.transform.stc.ClosureParams
+import groovy.transform.stc.FromString
 import org.gradle.api.Action
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
@@ -49,7 +51,7 @@ trait SnykToHtmlPluginExtension extends SnykInstallExtension implements SnykToHt
         snykToHtmlInstall.configure(action)
     }
 
-    void snykToHtmlInstall(Closure configure) {
+    void snykToHtmlInstall(@ClosureParams(value = FromString.class, options = ["wooga.gradle.snyk.tasks.SnykToHtmlInstall"]) Closure configure) {
         snykToHtmlInstall.configure(ConfigureUtil.configureUsing(configure))
     }
 }


### PR DESCRIPTION
## Description

A simple patch with type annotations for the configuration closures in the snyk extensions. This allows IDEs to have a better autocomplete. This only shows the type passed to the closure not the scope delegate. But it makes using of `it` a little saver.

Changes
=======

* ![IMPROVE] `Closure` parameter with type annotations

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
