### PR TITLE
Fix error in gradle option "init-script"  [ATLAS-681]

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/snyk/tasks/SnykCheckBaseIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/snyk/tasks/SnykCheckBaseIntegrationSpec.groovy
@@ -319,7 +319,7 @@ abstract class SnykCheckBaseIntegrationSpec<T extends SnykTask> extends SnykTask
         "initScript"                     | toProviderSet(property) | osPath("/path/to/initScript2")                              | _                                                 | "Provider<RegularFile>"
         "initScript"                     | toSetter(property)      | osPath("/path/to/initScript3")                              | _                                                 | "File"
         "initScript"                     | toSetter(property)      | osPath("/path/to/initScript4")                              | _                                                 | "Provider<RegularFile>"
-        "initScript"                     | "initScriptOption"      | osPath("/path/to/initScript5")                              | _                                                 | "String"
+        "initScript"                     | property                | osPath("/path/to/initScript5")                              | _                                                 | "String"
 
         "skipUnresolved"                 | toProviderSet(property) | true                                                        | _                                                 | "Boolean"
         "skipUnresolved"                 | toProviderSet(property) | true                                                        | _                                                 | "Provider<Boolean>"
@@ -437,7 +437,7 @@ abstract class SnykCheckBaseIntegrationSpec<T extends SnykTask> extends SnykTask
         "allSubProjects=true"                                                 | "--all-sub-projects"
         "configurationMatching=${wrap("foobar")}"                             | "--configuration-matching=foobar"
         "configurationAttributes=[${wrap("foo")},${wrap("bar")}]"             | "--configuration-attributes=foo,bar"
-        "initScript=${wrapValueBasedOnType("#projectDir#/foo.bar", File)}"    | "--gradle-init-script=${new File("#projectDir#/foo.bar").path}"
+        "initScript=${wrapValueBasedOnType("#projectDir#/foo.bar", File)}"    | "--init-script=${new File("#projectDir#/foo.bar").path}"
         "reachable=true"                                                      | "--reachable"
         "reachableTimeout=7"                                                  | "--reachable-timeout=7"
         "assetsProjectName=true"                                              | "--assets-project-name"

--- a/src/main/groovy/wooga/gradle/snyk/cli/SnykProjectSpec.groovy
+++ b/src/main/groovy/wooga/gradle/snyk/cli/SnykProjectSpec.groovy
@@ -213,10 +213,12 @@ trait SnykProjectSpec extends BaseSpec {
         initScript.set(value)
     }
 
+    // We don't use 'init-script' as the option name since it's already used  by gradle:
+    // https://docs.gradle.org/current/userguide/init_scripts.html
     @Option(option = "gradle-init-script", description = """
     Use for projects that contain a Gradle initialization script.
     """)
-    void initScriptOption(String value) {
+    void initScript(String value) {
         initScript.set(layout.projectDirectory.file(value))
     }
 

--- a/src/main/groovy/wooga/gradle/snyk/cli/options/ProjectOption.groovy
+++ b/src/main/groovy/wooga/gradle/snyk/cli/options/ProjectOption.groovy
@@ -22,7 +22,7 @@ enum ProjectOption implements OptionSpec {
     allSubProjects("--all-sub-projects", new SnykBooleanOption()),
     configurationMatching("--configuration-matching", new SnykStringOption()),
     configurationAttributes("--configuration-attributes", new SnykListOption(String.class)),
-    initScript("--gradle-init-script", new SnykFileOption()),
+    initScript("--init-script", new SnykFileOption()),
 
     // Maven, Gradle
     reachable("--reachable", new SnykBooleanOption()),


### PR DESCRIPTION
## Description

Fix option that was incorrectly named `gradle-init-script`. It is now `init-script`, as documented here:
https://docs.snyk.io/snyk-cli/commands/test#init-script-less-than-file

resolves #33

## Changes
* ![FIX]  Option that was incorrectly named `gradle-init-script` has been renamed to `init-script`

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
