### PR TITLE
Remove coveralls reporting [ATLAS-758]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@
  */
 
 plugins {
-    id 'net.wooga.plugins' version '3.1.0'
+    id 'net.wooga.plugins' version '4.0.0'
     id 'net.wooga.snyk' version '0.10.0'
     id "net.wooga.snyk-gradle-plugin" version "0.2.0"
     id "net.wooga.cve-dependency-resolution" version "0.4.0"

--- a/settings.gradle
+++ b/settings.gradle
@@ -28,4 +28,4 @@ pluginManagement {
   }
 }
 
-rootProject.name = 'atlas-snyk'
+rootProject.name = 'snyk'


### PR DESCRIPTION
## Description

Because of security issues reported for the coveralls gradle plugin I decided to remove the feature during build. It is not enough to just stop sending reports via jenkins. We also need to update to `net.wooga.plugins` > `4.0.0` because this version removes the dependency.

I remove the coveralls token in the Jenkinsfile so our base pipeline won't try to call the coveralls task on the gradle project.

## Changes

* ![UPDATE] `net.wooga.plugins` to version `4.0.0` to remove coveralls dependency
* ![REMOVE] coveralls token in Jenkinsfile

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
