### PR TITLE
Make snyk tasks failable with additional property

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/snyk/SnykPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/snyk/SnykPluginIntegrationSpec.groovy
@@ -206,6 +206,9 @@ class SnykPluginIntegrationSpec extends SnykIntegrationSpec {
         Monitor           | "debug"                          | true                                 | "Boolean"                         | ConventionSource.extension(extensionName, property)                 | _          || _
         Report            | "debug"                          | true                                 | "Boolean"                         | ConventionSource.extension(extensionName, property)                 | _          || _
 
+        Test              | "ignoreExitValue"                | true                                 | "Boolean"                         | ConventionSource.extension(extensionName, property)                 | _          || _
+        Monitor           | "ignoreExitValue"                | true                                 | "Boolean"                         | ConventionSource.extension(extensionName, property)                 | _          || _
+        Report            | "ignoreExitValue"                | true                                 | "Boolean"                         | ConventionSource.extension(extensionName, property)                 | _          || _
         value = (type != _) ? wrapValueBasedOnType(rawValue, type.toString(), wrapValueFallback) : rawValue
         testValue = (expectedValue == _) ? rawValue : expectedValue
     }
@@ -652,6 +655,13 @@ class SnykPluginIntegrationSpec extends SnykIntegrationSpec {
         "autoDownload"                   | toProviderSet(property) | true                                                            | _                                                                          | "Provider<Boolean>"                         | PropertyLocation.script
         "autoDownload"                   | toProviderSet(property) | false                                                           | _                                                                          | "Boolean"                                   | PropertyLocation.script
 
+        "ignoreExitValue"                | _                       | _                                                               | false                                                                      | "Provider<Boolean>"                         | PropertyLocation.none
+        "ignoreExitValue"                | _                       | "true"                                                          | true                                                                       | _                                           | PropertyLocation.environment
+        "ignoreExitValue"                | _                       | "true"                                                          | true                                                                       | _                                           | PropertyLocation.property
+        "ignoreExitValue"                | toSetter(property)      | true                                                            | _                                                                          | "Provider<Boolean>"                         | PropertyLocation.script
+        "ignoreExitValue"                | toSetter(property)      | false                                                           | _                                                                          | "Boolean"                                   | PropertyLocation.script
+        "ignoreExitValue"                | toProviderSet(property) | true                                                            | _                                                                          | "Provider<Boolean>"                         | PropertyLocation.script
+        "ignoreExitValue"                | toProviderSet(property) | false                                                           | _                                                                          | "Boolean"                                   | PropertyLocation.script
         value = (type != _) ? wrapValueBasedOnType(rawValue, type.toString(), wrapValueFallback) : rawValue
         providedValue = (location == PropertyLocation.script) ? type : value
         testValue = (expectedValue == _) ? rawValue : expectedValue

--- a/src/integrationTest/groovy/wooga/gradle/snyk/tasks/SnykTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/snyk/tasks/SnykTaskIntegrationSpec.groovy
@@ -16,14 +16,13 @@
 
 package wooga.gradle.snyk.tasks
 
-import com.wooga.gradle.PlatformUtils
+
 import com.wooga.gradle.test.PropertyQueryTaskWriter
 import org.gradle.api.file.Directory
 import spock.lang.Unroll
 import wooga.gradle.snyk.SnykIntegrationSpec
 
 import java.lang.reflect.ParameterizedType
-import java.nio.file.Files
 
 import static com.wooga.gradle.PlatformUtils.escapedPath
 import static com.wooga.gradle.test.PropertyUtils.toProviderSet
@@ -63,8 +62,11 @@ abstract class SnykTaskIntegrationSpec<T extends SnykTask> extends SnykIntegrati
         """.stripIndent()
     }
 
-    void setSnykWrapper(Boolean setDummyToken = true, String object = extensionName, Boolean printEnvironment = false, Boolean logToStdout = false) {
+    void setSnykWrapper(Boolean setDummyToken = true, String object = extensionName, Boolean printEnvironment = false, Boolean logToStdout = false, exitValue = 0) {
         def snykWrapper = generateBatchWrapper("snyk-wrapper", printEnvironment)
+        def lines = snykWrapper.readLines().dropRight(1)
+        snykWrapper.text = lines.join("\n")
+        snykWrapper << "exit ${exitValue}"
         def wrapperDir = snykWrapper.parent
         def wrapperPath = escapedPath(wrapperDir)
 
@@ -127,36 +129,41 @@ abstract class SnykTaskIntegrationSpec<T extends SnykTask> extends SnykIntegrati
         query.matches(result, expectedValue)
 
         where:
-        property         | method                  | rawValue                     | returnValue | type
-        "token"          | toProviderSet(property) | "some_token"                 | _           | "String"
-        "token"          | toProviderSet(property) | "some_token"                 | _           | "Provider<String>"
-        "token"          | toSetter(property)      | "some_token"                 | _           | "String"
-        "token"          | toSetter(property)      | "some_token"                 | _           | "Provider<String>"
+        property          | method                  | rawValue                     | returnValue | type
+        "token"           | toProviderSet(property) | "some_token"                 | _           | "String"
+        "token"           | toProviderSet(property) | "some_token"                 | _           | "Provider<String>"
+        "token"           | toSetter(property)      | "some_token"                 | _           | "String"
+        "token"           | toSetter(property)      | "some_token"                 | _           | "Provider<String>"
 
-        "logFile"        | toProviderSet(property) | osPath("/path/to/logFile")   | _           | "File"
-        "logFile"        | toProviderSet(property) | osPath("/path/to/logFile")   | _           | "Provider<RegularFile>"
-        "logFile"        | toSetter(property)      | osPath("/path/to/logFile")   | _           | "File"
-        "logFile"        | toSetter(property)      | osPath("/path/to/logFile")   | _           | "Provider<RegularFile>"
+        "logFile"         | toProviderSet(property) | osPath("/path/to/logFile")   | _           | "File"
+        "logFile"         | toProviderSet(property) | osPath("/path/to/logFile")   | _           | "Provider<RegularFile>"
+        "logFile"         | toSetter(property)      | osPath("/path/to/logFile")   | _           | "File"
+        "logFile"         | toSetter(property)      | osPath("/path/to/logFile")   | _           | "Provider<RegularFile>"
 
-        "executableName" | toProviderSet(property) | "snyk1"                      | _           | "String"
-        "executableName" | toProviderSet(property) | "snyk2"                      | _           | "Provider<String>"
-        "executableName" | toSetter(property)      | "snyk3"                      | _           | "String"
-        "executableName" | toSetter(property)      | "snyk4"                      | _           | "Provider<String>"
+        "executableName"  | toProviderSet(property) | "snyk1"                      | _           | "String"
+        "executableName"  | toProviderSet(property) | "snyk2"                      | _           | "Provider<String>"
+        "executableName"  | toSetter(property)      | "snyk3"                      | _           | "String"
+        "executableName"  | toSetter(property)      | "snyk4"                      | _           | "Provider<String>"
 
-        "snykPath"       | toProviderSet(property) | osPath("/path/to/snyk_home") | _           | "File"
-        "snykPath"       | toProviderSet(property) | osPath("/path/to/snyk_home") | _           | "Provider<Directory>"
-        "snykPath"       | toSetter(property)      | osPath("/path/to/snyk_home") | _           | "File"
-        "snykPath"       | toSetter(property)      | osPath("/path/to/snyk_home") | _           | "Provider<Directory>"
+        "snykPath"        | toProviderSet(property) | osPath("/path/to/snyk_home") | _           | "File"
+        "snykPath"        | toProviderSet(property) | osPath("/path/to/snyk_home") | _           | "Provider<Directory>"
+        "snykPath"        | toSetter(property)      | osPath("/path/to/snyk_home") | _           | "File"
+        "snykPath"        | toSetter(property)      | osPath("/path/to/snyk_home") | _           | "Provider<Directory>"
 
-        "insecure"       | toProviderSet(property) | true                         | _           | "Boolean"
-        "insecure"       | toProviderSet(property) | false                        | _           | "Provider<Boolean>"
-        "insecure"       | toSetter(property)      | true                         | _           | "Boolean"
-        "insecure"       | toSetter(property)      | false                        | _           | "Provider<Boolean>"
+        "insecure"        | toProviderSet(property) | true                         | _           | "Boolean"
+        "insecure"        | toProviderSet(property) | false                        | _           | "Provider<Boolean>"
+        "insecure"        | toSetter(property)      | true                         | _           | "Boolean"
+        "insecure"        | toSetter(property)      | false                        | _           | "Provider<Boolean>"
 
-        "debug"          | toProviderSet(property) | true                         | _           | "Boolean"
-        "debug"          | toProviderSet(property) | false                        | _           | "Provider<Boolean>"
-        "debug"          | toSetter(property)      | true                         | _           | "Boolean"
-        "debug"          | toSetter(property)      | false                        | _           | "Provider<Boolean>"
+        "debug"           | toProviderSet(property) | true                         | _           | "Boolean"
+        "debug"           | toProviderSet(property) | false                        | _           | "Provider<Boolean>"
+        "debug"           | toSetter(property)      | true                         | _           | "Boolean"
+        "debug"           | toSetter(property)      | false                        | _           | "Provider<Boolean>"
+
+        "ignoreExitValue" | toProviderSet(property) | true                         | _           | "Boolean"
+        "ignoreExitValue" | toProviderSet(property) | false                        | _           | "Provider<Boolean>"
+        "ignoreExitValue" | toSetter(property)      | true                         | _           | "Boolean"
+        "ignoreExitValue" | toSetter(property)      | false                        | _           | "Provider<Boolean>"
         value = wrapValueBasedOnType(rawValue, type, wrapValueFallback)
         expectedValue = returnValue == _ ? rawValue : returnValue
     }
@@ -191,7 +198,6 @@ abstract class SnykTaskIntegrationSpec<T extends SnykTask> extends SnykIntegrati
     }
 
     def "task is never up to date"() {
-
         given: "a set snyk wrapper"
         setSnykWrapper(true, subjectUnderTestName)
 
@@ -204,5 +210,28 @@ abstract class SnykTaskIntegrationSpec<T extends SnykTask> extends SnykIntegrati
         !firstRun.wasUpToDate(subjectUnderTestName)
         secondRun.success
         !secondRun.wasUpToDate(subjectUnderTestName)
+    }
+
+    @Unroll
+    def "task #taskTypeName with exit value #exitValue will #message"() {
+        given: "a set snyk wrapper"
+        setSnykWrapper(true, subjectUnderTestName, false, false, exitValue)
+        appendToSubjectTask("""
+        ignoreExitValue = true
+        """.stripIndent())
+
+        when:
+        def result = runTasks(subjectUnderTestName)
+
+        then:
+        result.success
+        result.wasExecuted(subjectUnderTestName)
+
+        where:
+        ignoreExitValue | expectSuccess | message
+        true            | true          | "succeed when ignoreExitValue is set"
+        false           | false         | "fail when ignoreExitValue is not set"
+        exitValue = 1
+        taskTypeName = subjectUnderTestTypeName
     }
 }

--- a/src/main/groovy/wooga/gradle/snyk/SnykConventions.groovy
+++ b/src/main/groovy/wooga/gradle/snyk/SnykConventions.groovy
@@ -391,4 +391,10 @@ class SnykConventions {
             "snyk.autoDownload",
             false
     )
+
+    static final PropertyLookup ignoreExitValue = new PropertyLookup(
+            "SNYK_IGNORE_EXIT_VALUE",
+            "snyk.ignoreExitValue",
+            null
+    )
 }

--- a/src/main/groovy/wooga/gradle/snyk/SnykPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/snyk/SnykPlugin.groovy
@@ -257,6 +257,7 @@ class SnykPlugin implements Plugin<Project>, ProjectRegistrationHandler {
         extension.jsonReportsEnabled.convention(parentExtension.jsonReportsEnabled)
         extension.sarifReportsEnabled.convention(parentExtension.sarifReportsEnabled)
         extension.htmlReportsEnabled.convention(parentExtension.htmlReportsEnabled)
+        extension.ignoreExitValue.convention(parentExtension.ignoreExitValue)
 
         extension
     }
@@ -409,8 +410,8 @@ class SnykPlugin implements Plugin<Project>, ProjectRegistrationHandler {
         extension.jsonReportsEnabled.convention(SnykConventions.jsonReportsEnabled.getBooleanValueProvider(project))
         extension.sarifReportsEnabled.convention(SnykConventions.sarifReportsEnabled.getBooleanValueProvider(project))
         extension.htmlReportsEnabled.convention(SnykConventions.htmlReportsEnabled.getBooleanValueProvider(project))
+        extension.ignoreExitValue.convention(SnykConventions.ignoreExitValue.getBooleanValueProvider(project))
         extension
-
     }
 
     private static mapExtensionPropertiesToBaseTask(SnykTask task, SnykPluginExtension extension, Project project) {
@@ -445,6 +446,7 @@ class SnykPlugin implements Plugin<Project>, ProjectRegistrationHandler {
         task.severityThreshold.convention(extension.severityThreshold)
         task.failOn.convention(extension.failOn)
         task.compilerArguments.convention(extension.compilerArguments)
+        task.ignoreExitValue.convention(extension.ignoreExitValue)
 
         task.strictOutOfSync.convention(extension.strictOutOfSync)
 

--- a/src/main/groovy/wooga/gradle/snyk/cli/SnykTaskSpec.groovy
+++ b/src/main/groovy/wooga/gradle/snyk/cli/SnykTaskSpec.groovy
@@ -97,4 +97,20 @@ trait SnykTaskSpec extends BaseSpec {
         workingDirectory.set(value)
     }
 
+    private final Property<Boolean> ignoreExitValue = objects.property(Boolean)
+
+    @Internal
+    Property<Boolean> getIgnoreExitValue() {
+        ignoreExitValue
+    }
+
+    void setIgnoreExitValue(Provider<Boolean> value) {
+        ignoreExitValue.set(value)
+    }
+
+    void setIgnoreExitValue(Boolean value) {
+        ignoreExitValue.set(value)
+    }
+
+
 }

--- a/src/main/groovy/wooga/gradle/snyk/tasks/Report.groovy
+++ b/src/main/groovy/wooga/gradle/snyk/tasks/Report.groovy
@@ -26,10 +26,6 @@ class Report extends SnykCheckBase {
 
     Report() {
         reports.html.required.set(true)
-    }
-
-    @Override
-    protected Boolean getIgnoreExitValue() {
-        true
+        ignoreExitValue.set(true)
     }
 }

--- a/src/main/groovy/wooga/gradle/snyk/tasks/SnykTask.groovy
+++ b/src/main/groovy/wooga/gradle/snyk/tasks/SnykTask.groovy
@@ -53,11 +53,6 @@ abstract class SnykTask extends DefaultTask
         outputs.upToDateWhen { false }
     }
 
-    @Internal
-    protected Boolean getIgnoreExitValue() {
-        false
-    }
-
     @TaskAction
     protected void exec() {
 
@@ -102,7 +97,7 @@ abstract class SnykTask extends DefaultTask
         })
 
         postAction(execResult)
-        if(!ignoreExitValue) {
+        if(!ignoreExitValue.getOrElse(false) ) {
             handleExitCode(execResult.exitValue)
         }
     }


### PR DESCRIPTION
## Description

This patch adds a new helper property `ignoreExitValue` to the base `SnykTask` class. This allows to make a single or all snyk tasks failable. A usecase I see is to leave the configuration alone (the default is the old default: fail on error, exception is `Report` task).

We can then set a global environment variable `SNYK_IGNORE_EXIT_VALUE=1` which will activate the flag for all tasks.

## Changes

* ![IMPROVE] make `snyk` tasks failable with additional property `ignoreExitValue`

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
